### PR TITLE
fix(deps): update glob and js-yaml to fix security vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.2] - 2025-11-19
+
+### Security
+- **Fixed npm Security Vulnerabilities**:
+  - **glob** (10.4.5 → 10.5.0): Resolved high severity command injection vulnerability
+    - CVE: [GHSA-5j98-mcp5-4vw2](https://github.com/advisories/GHSA-5j98-mcp5-4vw2)
+    - Issue: glob CLI could execute matches with `shell:true` via `-c/--cmd` flag
+  - **js-yaml** (4.1.0 → 4.1.1): Resolved moderate severity prototype pollution vulnerability
+    - CVE: [GHSA-mh29-5h37-fv8m](https://github.com/advisories/GHSA-mh29-5h37-fv8m)
+    - Issue: Prototype pollution in merge (`<<`) operator
+
+### Changed
+- **build(deps)**: Updated npm dependencies via `npm audit fix`:
+  - glob: 10.4.5 → 10.5.0
+  - js-yaml: 4.1.0 → 4.1.1
+
+
 ## [1.6.1] - 2025-11-13
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -4576,9 +4576,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5091,9 +5091,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
### Security
- **Fixed npm Security Vulnerabilities**:
  - **glob** (10.4.5 → 10.5.0): Resolved high severity command injection vulnerability
    - CVE: [GHSA-5j98-mcp5-4vw2](https://github.com/advisories/GHSA-5j98-mcp5-4vw2)
    - Issue: glob CLI could execute matches with `shell:true` via `-c/--cmd` flag
  - **js-yaml** (4.1.0 → 4.1.1): Resolved moderate severity prototype pollution vulnerability
    - CVE: [GHSA-mh29-5h37-fv8m](https://github.com/advisories/GHSA-mh29-5h37-fv8m)
    - Issue: Prototype pollution in merge (`<<`) operator

### Changed
- **build(deps)**: Updated npm dependencies via `npm audit fix`:
  - glob: 10.4.5 → 10.5.0
  - js-yaml: 4.1.0 → 4.1.1