### PR TITLE
feat: add frontend pagination for search results

### DIFF
--- a/.env
+++ b/.env
@@ -46,6 +46,7 @@ MAILER_DSN=null://null
 ELASTIC_PASSWORD=ignored_in_dev
 ELASTICSEARCH_HOST=http://elasticsearch:9200
 ELASTICSEARCH_INDEX_PDFS=pdf_pages
+ELASTICSEARCH_MAX_RESULTS=100
 # Production: set strong ELASTIC_PASSWORD in .env.prod.local
 # Production ELASTICSEARCH_HOST: http://elastic:${ELASTIC_PASSWORD}@elasticsearch:9200
 ###< Elasticsearch ###

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+---
+
+## [Unreleased]
+
+### Added
+- **Frontend Pagination**: Client-side pagination for search results (10 results per page)
+  - `Pagination.vue` component with prev/next, page numbers, and ellipsis navigation
+  - "Showing 1-10 of 42 results" range display in Controls
+  - Scroll-to-top on page change, auto-reset on new search
+  - Global position offset for accurate click analytics tracking
+  - `PAGINATION.PAGE_SIZE` constant in `assets/constants/pagination.js`
+- **Elasticsearch Safety Cap**: Configurable `ELASTICSEARCH_MAX_RESULTS` env var (default: 100) to limit lexical query result sets
+
+### Dependencies
+
+**CI/CD:**
+- github/codeql-action: 4.31.11 → 4.32.2 ([#79](https://github.com/josego85/pdf-content-search/pull/79), [#80](https://github.com/josego85/pdf-content-search/pull/80))
+
+
+---
+
 ## [1.11.1] - 2026-01-30
 
 ### Changed

--- a/assets/components/search/Controls.vue
+++ b/assets/components/search/Controls.vue
@@ -4,7 +4,9 @@
     <div class="flex items-center justify-between text-xs sm:text-sm gap-2">
       <div class="flex items-center gap-2 flex-wrap">
         <p class="text-gray-600">
-          <span class="hidden sm:inline">Found </span>
+          <span class="hidden sm:inline">Showing </span>
+          <span class="font-semibold text-gray-900">{{ from }}-{{ to }}</span>
+          of
           <span class="font-semibold text-gray-900">{{ resultCount }}</span>
           {{ resultCount === 1 ? 'result' : 'results' }}
           <span v-if="duration" class="text-gray-400 hidden sm:inline">in {{ duration }}ms</span>
@@ -44,6 +46,14 @@ export default {
 	name: "Controls",
 	props: {
 		resultCount: {
+			type: Number,
+			required: true,
+		},
+		from: {
+			type: Number,
+			required: true,
+		},
+		to: {
 			type: Number,
 			required: true,
 		},

--- a/assets/components/search/Pagination.vue
+++ b/assets/components/search/Pagination.vue
@@ -1,0 +1,111 @@
+<template>
+  <nav
+    v-if="totalPages > 1"
+    class="flex items-center justify-center gap-1 sm:gap-2 mt-6 sm:mt-8"
+    aria-label="Pagination"
+  >
+    <!-- Previous -->
+    <button
+      @click="$emit('update:currentPage', currentPage - 1)"
+      :disabled="currentPage === 1"
+      class="p-2 sm:p-2.5 rounded-lg transition-colors touch-manipulation"
+      :class="currentPage === 1
+        ? 'text-gray-300 cursor-not-allowed'
+        : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'"
+      aria-label="Previous page"
+    >
+      <svg class="w-4 h-4 sm:w-5 sm:h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+      </svg>
+    </button>
+
+    <!-- Page Numbers -->
+    <template v-for="page in visiblePages" :key="page">
+      <span
+        v-if="page === '...'"
+        class="px-2 text-gray-400 text-sm select-none"
+      >...</span>
+      <button
+        v-else
+        @click="$emit('update:currentPage', page)"
+        class="min-w-[36px] sm:min-w-[40px] h-9 sm:h-10 rounded-lg text-sm font-medium transition-colors touch-manipulation"
+        :class="page === currentPage
+          ? 'bg-blue-600 text-white shadow-sm'
+          : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'"
+        :aria-label="'Page ' + page"
+        :aria-current="page === currentPage ? 'page' : undefined"
+      >
+        {{ page }}
+      </button>
+    </template>
+
+    <!-- Next -->
+    <button
+      @click="$emit('update:currentPage', currentPage + 1)"
+      :disabled="currentPage === totalPages"
+      class="p-2 sm:p-2.5 rounded-lg transition-colors touch-manipulation"
+      :class="currentPage === totalPages
+        ? 'text-gray-300 cursor-not-allowed'
+        : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'"
+      aria-label="Next page"
+    >
+      <svg class="w-4 h-4 sm:w-5 sm:h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+      </svg>
+    </button>
+  </nav>
+</template>
+
+<script>
+export default {
+	name: "Pagination",
+	props: {
+		currentPage: {
+			type: Number,
+			required: true,
+		},
+		totalPages: {
+			type: Number,
+			required: true,
+		},
+	},
+	emits: ["update:currentPage"],
+	computed: {
+		visiblePages() {
+			const total = this.totalPages
+			const current = this.currentPage
+			const pages = []
+
+			if (total <= 7) {
+				for (let i = 1; i <= total; i++) {
+					pages.push(i)
+				}
+				return pages
+			}
+
+			// Always show first page
+			pages.push(1)
+
+			if (current > 3) {
+				pages.push("...")
+			}
+
+			// Pages around current
+			const start = Math.max(2, current - 1)
+			const end = Math.min(total - 1, current + 1)
+			for (let i = start; i <= end; i++) {
+				pages.push(i)
+			}
+
+			if (current < total - 2) {
+				pages.push("...")
+			}
+
+			// Always show last page
+			pages.push(total)
+
+			return pages
+		},
+	},
+}
+</script>

--- a/assets/components/search/Results.vue
+++ b/assets/components/search/Results.vue
@@ -4,7 +4,7 @@
       v-for="(result, index) in results"
       :key="result?._id || index"
       :result="result"
-      :position="index + 1"
+      :position="index + 1 + offset"
       :query="query"
       @open="$emit('open', result)"
     />
@@ -23,6 +23,10 @@ export default {
 		results: {
 			type: Array,
 			required: true,
+		},
+		offset: {
+			type: Number,
+			default: 0,
 		},
 		viewMode: {
 			type: String,

--- a/assets/constants/pagination.js
+++ b/assets/constants/pagination.js
@@ -1,0 +1,8 @@
+/**
+ * Pagination configuration constants.
+ * Single source of truth for pagination settings.
+ */
+
+export const PAGINATION = {
+	PAGE_SIZE: 10,
+}

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -5,6 +5,7 @@
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
     elasticsearch.index_pdfs: '%env(ELASTICSEARCH_INDEX_PDFS)%'
+    elasticsearch.max_results: '%env(int:ELASTICSEARCH_MAX_RESULTS)%'
 
 services:
     # default configuration for services in *this* file
@@ -54,6 +55,7 @@ services:
     App\Search\SearchQueryBuilder:
         arguments:
             $pdfPagesIndex: '%elasticsearch.index_pdfs%'
+            $maxResults: '%elasticsearch.max_results%'
 
     App\Search\HybridSearchQueryBuilder:
         arguments:

--- a/src/Search/SearchQueryBuilder.php
+++ b/src/Search/SearchQueryBuilder.php
@@ -18,7 +18,8 @@ final readonly class SearchQueryBuilder implements QueryBuilderInterface
 
     public function __construct(
         private QueryParser $parser,
-        private string $pdfPagesIndex
+        private string $pdfPagesIndex,
+        private int $maxResults = 100
     ) {
     }
 
@@ -34,6 +35,7 @@ final readonly class SearchQueryBuilder implements QueryBuilderInterface
             'body' => [
                 'query' => $this->buildQuery($query, $parsedQuery, $strategy),
                 'highlight' => $this->buildHighlight(),
+                'size' => $this->maxResults,
             ],
         ];
     }


### PR DESCRIPTION
### Added
- **Frontend Pagination**: Client-side pagination for search results (10 results per page)
  - `Pagination.vue` component with prev/next, page numbers, and ellipsis navigation
  - "Showing 1-10 of 42 results" range display in Controls
  - Scroll-to-top on page change, auto-reset on new search
  - Global position offset for accurate click analytics tracking
  - `PAGINATION.PAGE_SIZE` constant in `assets/constants/pagination.js`
- **Elasticsearch Safety Cap**: Configurable `ELASTICSEARCH_MAX_RESULTS` env var (default: 100) to limit lexical query result sets