### PR TITLE
Feat/phpstan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           coverage: pcov
 
       - name: Validate composer files
-        run: composer validate --no-check-publish
+        run: composer validate --no-check-publish --no-check-all
 
       - name: Setup Node.js project
         uses: ./.github/actions/setup-node-project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,23 @@ jobs:
           fi
           echo "✅ Coverage ${COVERAGE}% meets 85% threshold"
 
+  static-analysis:
+    name: PHPStan Static Analysis
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5.0.0
+
+      - name: Setup PHP project
+        uses: ./.github/actions/setup-php-project
+
+      - name: Generate Symfony container cache
+        run: php bin/console cache:warmup --env=dev
+
+      - name: Run PHPStan
+        run: composer phpstan
+
   code-style:
     name: PHP Code Style
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ yarn-error.log
 .php-cs-fixer.php
 .php-cs-fixer.cache
 ###< friendsofphp/php-cs-fixer ###
+
+###> phpstan/phpstan ###
+phpstan.cache/
+###< phpstan/phpstan ###

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -18,6 +18,17 @@ fi
 echo "✅ PHP code style is clean."
 echo ""
 
+echo "🔬 Running PHPStan static analysis..."
+docker compose exec -T php composer phpstan
+
+if [ $? -ne 0 ]; then
+  echo "❌ PHPStan found errors. Please fix them before committing."
+  exit 1
+fi
+
+echo "✅ PHPStan analysis passed."
+echo ""
+
 echo "🧪 Running PHP tests..."
 docker compose exec -T php bash -c "XDEBUG_MODE=coverage php bin/phpunit"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `PAGINATION.PAGE_SIZE` constant in `assets/constants/pagination.js`
 - **Elasticsearch Safety Cap**: Configurable `ELASTICSEARCH_MAX_RESULTS` env var (default: 100) to limit lexical query result sets
 - **PHPStan Static Analysis**: Level 8 with Symfony and Doctrine extensions
-  - `phpstan.neon` config with baseline for gradual adoption (32 remaining errors)
+  - `phpstan.neon` config with baseline for gradual adoption (5 remaining errors)
   - CI job `static-analysis` in GitHub Actions pipeline
   - Pre-commit hook integration via Husky
   - `composer phpstan` script and `make phpstan` target
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Unhandled `false` returns from `getmypid()`, `strrpos()`, `preg_split()`, `preg_replace()`, `shell_exec()`
 - **PHPStan PHPDoc types**: Add `@param`/`@return` array type annotations across 12 files (36 errors resolved)
   - Contracts, Search builders, Services, Repository, Message classes
+- **TranslationJob entity**: Initialize non-nullable DB columns with proper defaults instead of `null`
+- **TranslationOrchestrator**: Type-safe casts after validation (resolve 16 nullable chain errors)
+- **Dead code removal**: Remove always-true `if ($job)` guard in `TranslatePageMessageHandler`
+- **SearchQueryBuilder**: Add default fallback to match expression for unhandled strategies
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Global position offset for accurate click analytics tracking
   - `PAGINATION.PAGE_SIZE` constant in `assets/constants/pagination.js`
 - **Elasticsearch Safety Cap**: Configurable `ELASTICSEARCH_MAX_RESULTS` env var (default: 100) to limit lexical query result sets
+- **PHPStan Static Analysis**: Level 8 with Symfony and Doctrine extensions
+  - `phpstan.neon` config with baseline for gradual adoption (86 existing errors)
+  - CI job `static-analysis` in GitHub Actions pipeline
+  - Pre-commit hook integration via Husky
+  - `composer phpstan` script and `make phpstan` target
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `PAGINATION.PAGE_SIZE` constant in `assets/constants/pagination.js`
 - **Elasticsearch Safety Cap**: Configurable `ELASTICSEARCH_MAX_RESULTS` env var (default: 100) to limit lexical query result sets
 - **PHPStan Static Analysis**: Level 8 with Symfony and Doctrine extensions
-  - `phpstan.neon` config with baseline for gradual adoption (86 existing errors)
+  - `phpstan.neon` config with baseline for gradual adoption (32 remaining errors)
   - CI job `static-analysis` in GitHub Actions pipeline
   - Pre-commit hook integration via Husky
   - `composer phpstan` script and `make phpstan` target
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Unused `$jobRepository` dependency (`TranslationOrchestrator`)
   - Missing `instanceof` type guard on `findOneBy()` result (`AnalyticsController`)
   - Unhandled `false` returns from `getmypid()`, `strrpos()`, `preg_split()`, `preg_replace()`, `shell_exec()`
+- **PHPStan PHPDoc types**: Add `@param`/`@return` array type annotations across 12 files (36 errors resolved)
+  - Contracts, Search builders, Services, Repository, Message classes
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **TranslationOrchestrator**: Type-safe casts after validation (resolve 16 nullable chain errors)
 - **Dead code removal**: Remove always-true `if ($job)` guard in `TranslatePageMessageHandler`
 - **SearchQueryBuilder**: Add default fallback to match expression for unhandled strategies
+- **CI**: Fix `composer validate` failure caused by exact version constraint warnings (`--no-check-all`)
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Pre-commit hook integration via Husky
   - `composer phpstan` script and `make phpstan` target
 
+### Fixed
+- **PHPStan type safety**: Fix 18 real bugs detected by static analysis
+  - Nullsafe operator on guaranteed non-null variable (`OllamaEmbeddingService`)
+  - Unused `$jobRepository` dependency (`TranslationOrchestrator`)
+  - Missing `instanceof` type guard on `findOneBy()` result (`AnalyticsController`)
+  - Unhandled `false` returns from `getmypid()`, `strrpos()`, `preg_split()`, `preg_replace()`, `shell_exec()`
+
 ### Dependencies
 
 **Backend:**

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # ============================================
 
 .DEFAULT_GOAL := help
-.PHONY: help dev prod up down restart logs shell test clean rebuild status
+.PHONY: help dev prod up down restart logs shell test phpstan clean rebuild status
 
 # Colors for output
 BLUE := \033[0;34m
@@ -61,6 +61,7 @@ help: ## Show this help message
 	@echo "  $(YELLOW)make rebuild$(NC)          Rebuild images (ENV=dev|prod)"
 	@echo "  $(YELLOW)make clean$(NC)            Remove volumes - DESTRUCTIVE (ENV=dev|prod)"
 	@echo "  $(YELLOW)make test$(NC)             Run tests"
+	@echo "  $(YELLOW)make phpstan$(NC)          Run PHPStan static analysis"
 	@echo ""
 	@echo "$(GREEN)Examples:$(NC)"
 	@echo "  $(YELLOW)make dev$(NC)              # Start development"
@@ -149,6 +150,9 @@ clean: ## Remove ALL data for environment (ENV=dev|prod) - DESTRUCTIVE
 
 test: ## Run tests in development environment
 	@$(COMPOSE_DEV) exec php php bin/phpunit
+
+phpstan: ## Run PHPStan static analysis
+	@$(COMPOSE_DEV) exec php composer phpstan
 
 # ============================================
 # Internal Helpers (don't call directly)

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,6 @@
 
 ### Infrastructure
 - [ ] **Composer Security Audit** - Add `composer audit` to CI/CD pipeline
-- [ ] **PHP Stan** - Add static analysis to CI/CD
 
 ## 🟡 Medium Priority
 

--- a/composer.json
+++ b/composer.json
@@ -80,6 +80,7 @@
   "scripts": {
     "cs-check": "php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.dist.php",
     "cs-fix": "php-cs-fixer fix --config=.php-cs-fixer.dist.php",
+    "phpstan": "phpstan analyse",
     "auto-scripts": {
       "cache:clear": "symfony-cmd",
       "assets:install %PUBLIC_DIR%": "symfony-cmd",
@@ -99,6 +100,9 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "3.94.0",
+    "phpstan/phpstan": "2.1.39",
+    "phpstan/phpstan-doctrine": "2.0.16",
+    "phpstan/phpstan-symfony": "2.0.14",
     "phpunit/phpunit": "9.6.34",
     "symfony/browser-kit": ">=7.4.0",
     "symfony/css-selector": ">=7.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d91f0055d1fc767c97c74c5ccf57bbe5",
+    "content-hash": "cd1188d715dcc26402df5a309c44e4ad",
     "packages": [
         {
             "name": "composer/semver",
@@ -9242,6 +9242,209 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.39",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c6f73a2af4cbcd99c931d0fb8f08548cc0fa8224",
+                "reference": "c6f73a2af4cbcd99c931d0fb8f08548cc0fa8224",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-11T14:48:56+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-doctrine",
+            "version": "2.0.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-doctrine.git",
+                "reference": "f4ff6084a26d91174b3f0b047589af293a893104"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/f4ff6084a26d91174b3f0b047589af293a893104",
+                "reference": "f4ff6084a26d91174b3f0b047589af293a893104",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.1.34"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.0",
+                "doctrine/common": "<2.7",
+                "doctrine/mongodb-odm": "<1.2",
+                "doctrine/orm": "<2.5",
+                "doctrine/persistence": "<1.3"
+            },
+            "require-dev": {
+                "cache/array-adapter": "^1.1",
+                "composer/semver": "^3.3.2",
+                "cweagans/composer-patches": "^1.7.3",
+                "doctrine/annotations": "^2.0",
+                "doctrine/collections": "^1.6 || ^2.1",
+                "doctrine/common": "^2.7 || ^3.0",
+                "doctrine/dbal": "^3.3.8",
+                "doctrine/lexer": "^2.0 || ^3.0",
+                "doctrine/mongodb-odm": "^2.4.3",
+                "doctrine/orm": "^2.16.0",
+                "doctrine/persistence": "^2.2.1 || ^3.2",
+                "gedmo/doctrine-extensions": "^3.8",
+                "nesbot/carbon": "^2.49",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-deprecation-rules": "^2.0.2",
+                "phpstan/phpstan-phpunit": "^2.0.8",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6.20",
+                "ramsey/uuid": "^4.2",
+                "symfony/cache": "^5.4",
+                "symfony/uid": "^5.4 || ^6.4 || ^7.3"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Doctrine extensions for PHPStan",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-doctrine/issues",
+                "source": "https://github.com/phpstan/phpstan-doctrine/tree/2.0.16"
+            },
+            "time": "2026-02-11T08:54:45+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-symfony",
+            "version": "2.0.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-symfony.git",
+                "reference": "678136545a552a33b07f1a59a013f76df286cc34"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/678136545a552a33b07f1a59a013f76df286cc34",
+                "reference": "678136545a552a33b07f1a59a013f76df286cc34",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.1.13"
+            },
+            "conflict": {
+                "symfony/framework-bundle": "<3.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^2.0.8",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "psr/container": "1.1.2",
+                "symfony/config": "^5.4 || ^6.1",
+                "symfony/console": "^5.4 || ^6.1",
+                "symfony/dependency-injection": "^5.4 || ^6.1",
+                "symfony/form": "^5.4 || ^6.1",
+                "symfony/framework-bundle": "^5.4 || ^6.1",
+                "symfony/http-foundation": "^5.4 || ^6.1",
+                "symfony/messenger": "^5.4",
+                "symfony/polyfill-php80": "^1.24",
+                "symfony/serializer": "^5.4",
+                "symfony/service-contracts": "^2.2.0"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Lukáš Unger",
+                    "email": "looky.msc@gmail.com",
+                    "homepage": "https://lookyman.net"
+                }
+            ],
+            "description": "Symfony Framework extensions and rules for PHPStan",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-symfony/issues",
+                "source": "https://github.com/phpstan/phpstan-symfony/tree/2.0.14"
+            },
+            "time": "2026-02-11T12:27:30+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cd1188d715dcc26402df5a309c44e4ad",
+    "content-hash": "f0599e5bbfd3f55c815a73d64d73c2ef",
     "packages": [
         {
             "name": "composer/semver",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,31 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^While loop condition is always true\.$#'
+			identifier: while.alwaysTrue
+			count: 1
+			path: src/Command/TranslationJobsMonitorCommand.php
+
+		-
+			message: '#^Call to an undefined method Elastic\\Elasticsearch\\Response\\Elasticsearch\|Http\\Promise\\Promise\:\:asArray\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Service/ElasticsearchService.php
+
+		-
+			message: '#^Call to an undefined method Elastic\\Elasticsearch\\Response\\Elasticsearch\|Http\\Promise\\Promise\:\:asBool\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Service/ElasticsearchService.php
+
+		-
+			message: '#^Call to an undefined method Elastic\\Elasticsearch\\Response\\Elasticsearch\|Http\\Promise\\Promise\:\:asArray\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Service/ElasticsearchVectorStore.php
+
+		-
+			message: '#^Method App\\Service\\LanguageDetector\:\:detect\(\) should return array\{language\: string, confidence\: float, all\: array\<string, float\>\} but returns array\{language\: int\|string, confidence\: mixed, all\: array\}\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Service/LanguageDetector.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,15 @@
+parameters:
+    level: 8
+    paths:
+        - src/
+    symfony:
+        containerXmlPath: var/cache/dev/App_KernelDevDebugContainer.xml
+    excludePaths:
+        - src/Kernel.php
+
+includes:
+    - phpstan-baseline.neon
+    - vendor/phpstan/phpstan-symfony/extension.neon
+    - vendor/phpstan/phpstan-symfony/rules.neon
+    - vendor/phpstan/phpstan-doctrine/extension.neon
+    - vendor/phpstan/phpstan-doctrine/rules.neon

--- a/src/Contract/IndexManagementInterface.php
+++ b/src/Contract/IndexManagementInterface.php
@@ -6,6 +6,9 @@ namespace App\Contract;
 
 interface IndexManagementInterface
 {
+    /**
+     * @param array<string, mixed> $settings
+     */
     public function createIndex(array $settings = []): void;
 
     public function deleteIndex(): void;

--- a/src/Contract/QueryBuilderInterface.php
+++ b/src/Contract/QueryBuilderInterface.php
@@ -18,7 +18,7 @@ interface QueryBuilderInterface
      * @param string $query User search query
      * @param SearchStrategy $strategy Search strategy to apply
      *
-     * @return array Engine-specific query parameters
+     * @return array<string, mixed> Engine-specific query parameters
      */
     public function build(string $query, SearchStrategy $strategy = SearchStrategy::HYBRID): array;
 }

--- a/src/Contract/SearchEngineInterface.php
+++ b/src/Contract/SearchEngineInterface.php
@@ -6,7 +6,15 @@ namespace App\Contract;
 
 interface SearchEngineInterface
 {
+    /**
+     * @param array<string, mixed> $data
+     */
     public function indexDocument(string $index, string $id, array $data): void;
 
+    /**
+     * @param array<string, mixed> $query
+     *
+     * @return array<string, mixed>
+     */
     public function search(array $query): array;
 }

--- a/src/Controller/AnalyticsController.php
+++ b/src/Controller/AnalyticsController.php
@@ -189,7 +189,7 @@ final class AnalyticsController extends AbstractController
             ['createdAt' => 'DESC']
         );
 
-        if ($analytics) {
+        if ($analytics instanceof \App\Entity\SearchAnalytics) {
             $analytics->setClicked(true);
             $analytics->setClickedPosition($position);
             $analytics->setClickedPdf($pdfPath);

--- a/src/Entity/TranslationJob.php
+++ b/src/Entity/TranslationJob.php
@@ -24,19 +24,19 @@ class TranslationJob
     private ?int $id = null;
 
     #[ORM\Column(length: 255)]
-    private ?string $pdfFilename = null;
+    private string $pdfFilename = '';
 
     #[ORM\Column]
-    private ?int $pageNumber = null;
+    private int $pageNumber = 0;
 
     #[ORM\Column(length: 10)]
-    private ?string $targetLanguage = null;
+    private string $targetLanguage = 'es';
 
     #[ORM\Column(length: 20)]
-    private ?string $status = null;
+    private string $status = 'queued';
 
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    private ?\DateTimeInterface $createdAt = null;
+    private \DateTimeInterface $createdAt;
 
     #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
     private ?\DateTimeInterface $startedAt = null;
@@ -53,7 +53,6 @@ class TranslationJob
     public function __construct()
     {
         $this->createdAt = new \DateTime();
-        $this->status = 'queued';
     }
 
     public function getId(): ?int
@@ -61,7 +60,7 @@ class TranslationJob
         return $this->id;
     }
 
-    public function getPdfFilename(): ?string
+    public function getPdfFilename(): string
     {
         return $this->pdfFilename;
     }
@@ -73,7 +72,7 @@ class TranslationJob
         return $this;
     }
 
-    public function getPageNumber(): ?int
+    public function getPageNumber(): int
     {
         return $this->pageNumber;
     }
@@ -85,7 +84,7 @@ class TranslationJob
         return $this;
     }
 
-    public function getTargetLanguage(): ?string
+    public function getTargetLanguage(): string
     {
         return $this->targetLanguage;
     }
@@ -97,7 +96,7 @@ class TranslationJob
         return $this;
     }
 
-    public function getStatus(): ?string
+    public function getStatus(): string
     {
         return $this->status;
     }
@@ -109,7 +108,7 @@ class TranslationJob
         return $this;
     }
 
-    public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): \DateTimeInterface
     {
         return $this->createdAt;
     }

--- a/src/Message/LogSearchAnalyticsMessage.php
+++ b/src/Message/LogSearchAnalyticsMessage.php
@@ -6,11 +6,17 @@ namespace App\Message;
 
 final class LogSearchAnalyticsMessage
 {
+    /**
+     * @param array<string, mixed> $data
+     */
     public function __construct(
         private readonly array $data
     ) {
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getData(): array
     {
         return $this->data;

--- a/src/MessageHandler/LogSearchAnalyticsHandler.php
+++ b/src/MessageHandler/LogSearchAnalyticsHandler.php
@@ -51,7 +51,9 @@ final class LogSearchAnalyticsHandler
     {
         if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
             // IPv4: Keep first 3 octets, zero last octet
-            return substr($ip, 0, strrpos($ip, '.')) . '.0';
+            $lastDot = strrpos($ip, '.');
+
+            return $lastDot !== false ? substr($ip, 0, $lastDot) . '.0' : '0.0.0.0';
         }
 
         if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {

--- a/src/MessageHandler/TranslatePageMessageHandler.php
+++ b/src/MessageHandler/TranslatePageMessageHandler.php
@@ -92,10 +92,8 @@ final class TranslatePageMessageHandler
             );
         } catch (\Exception $e) {
             // Mark job as failed
-            if ($job) {
-                $job->markAsFailed($e->getMessage());
-                $this->entityManager->flush();
-            }
+            $job->markAsFailed($e->getMessage());
+            $this->entityManager->flush();
 
             $this->logger->error('Translation failed', [
                 'pdf' => $message->getPdfFilename(),

--- a/src/MessageHandler/TranslatePageMessageHandler.php
+++ b/src/MessageHandler/TranslatePageMessageHandler.php
@@ -50,14 +50,15 @@ final class TranslatePageMessageHandler
         }
 
         // Mark as processing with worker PID
-        $job->markAsProcessing(getmypid());
+        $pid = getmypid() ?: 0;
+        $job->markAsProcessing($pid);
         $this->entityManager->flush();
 
         $this->logger->info('Starting async translation', [
             'pdf' => $message->getPdfFilename(),
             'page' => $message->getPageNumber(),
             'target_language' => $message->getTargetLanguage(),
-            'worker_pid' => getmypid(),
+            'worker_pid' => $pid,
         ]);
 
         try {

--- a/src/Repository/SearchAnalyticsRepository.php
+++ b/src/Repository/SearchAnalyticsRepository.php
@@ -8,6 +8,9 @@ use App\Entity\SearchAnalytics;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
+/**
+ * @extends ServiceEntityRepository<SearchAnalytics>
+ */
 class SearchAnalyticsRepository extends ServiceEntityRepository
 {
     public function __construct(ManagerRegistry $registry)
@@ -17,6 +20,8 @@ class SearchAnalyticsRepository extends ServiceEntityRepository
 
     /**
      * Get overview metrics for dashboard.
+     *
+     * @return array<string, mixed>
      */
     public function getOverviewMetrics(\DateTime $startDate, \DateTime $endDate): array
     {
@@ -40,6 +45,8 @@ class SearchAnalyticsRepository extends ServiceEntityRepository
 
     /**
      * Get top queries by search count.
+     *
+     * @return list<array<string, mixed>>
      */
     public function getTopQueries(\DateTime $startDate, \DateTime $endDate, int $limit = 20): array
     {
@@ -63,6 +70,8 @@ class SearchAnalyticsRepository extends ServiceEntityRepository
 
     /**
      * Get search volume trends (daily aggregation).
+     *
+     * @return list<array<string, mixed>>
      */
     public function getSearchTrends(\DateTime $startDate, \DateTime $endDate): array
     {
@@ -90,6 +99,8 @@ class SearchAnalyticsRepository extends ServiceEntityRepository
 
     /**
      * Get click position distribution.
+     *
+     * @return list<array<string, mixed>>
      */
     public function getClickPositionDistribution(\DateTime $startDate, \DateTime $endDate): array
     {
@@ -111,6 +122,8 @@ class SearchAnalyticsRepository extends ServiceEntityRepository
 
     /**
      * Get zero-result queries (queries that need content).
+     *
+     * @return list<array<string, mixed>>
      */
     public function getZeroResultQueries(\DateTime $startDate, \DateTime $endDate, int $limit = 20): array
     {

--- a/src/Search/HybridSearchQueryBuilder.php
+++ b/src/Search/HybridSearchQueryBuilder.php
@@ -23,6 +23,9 @@ final readonly class HybridSearchQueryBuilder implements QueryBuilderInterface
     ) {
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function build(string $query, SearchStrategy $strategy = SearchStrategy::HYBRID): array
     {
         return match ($strategy) {
@@ -35,6 +38,8 @@ final readonly class HybridSearchQueryBuilder implements QueryBuilderInterface
     /**
      * Build pure semantic search query using vector store abstraction.
      * Now database-agnostic: works with Elasticsearch, Pinecone, Weaviate, etc.
+     *
+     * @return array<string, mixed>
      */
     private function buildSemanticQuery(string $query): array
     {
@@ -58,6 +63,8 @@ final readonly class HybridSearchQueryBuilder implements QueryBuilderInterface
     /**
      * Build hybrid AI query: returns both lexical and semantic queries to be executed in parallel.
      * Results will be merged using RRF by the controller.
+     *
+     * @return array<string, mixed>
      */
     private function buildHybridAiQuery(string $query): array
     {

--- a/src/Search/QueryParser.php
+++ b/src/Search/QueryParser.php
@@ -44,11 +44,11 @@ final readonly class QueryParser
             $result['phrases'] = $matches[1];
             $result['hasOperators'] = true;
             // Remove phrases from query
-            $query = preg_replace('/"[^"]+"/', '', $query);
+            $query = preg_replace('/"[^"]+"/', '', $query) ?? $query;
         }
 
         // Extract individual terms
-        $terms = preg_split('/\s+/', $query, -1, PREG_SPLIT_NO_EMPTY);
+        $terms = preg_split('/\s+/', $query, -1, PREG_SPLIT_NO_EMPTY) ?: [];
 
         foreach ($terms as $term) {
             if (empty($term)) {
@@ -85,10 +85,10 @@ final readonly class QueryParser
         $clean = str_replace('"', '', $query);
 
         // Remove +/- operators
-        $clean = preg_replace('/[+-](\S+)/', '$1', $clean);
+        $clean = preg_replace('/[+-](\S+)/', '$1', $clean) ?? $clean;
 
         // Normalize spaces
-        $clean = preg_replace('/\s+/', ' ', $clean);
+        $clean = preg_replace('/\s+/', ' ', $clean) ?? $clean;
 
         return trim($clean);
     }

--- a/src/Search/SearchQueryBuilder.php
+++ b/src/Search/SearchQueryBuilder.php
@@ -64,7 +64,7 @@ final readonly class SearchQueryBuilder implements QueryBuilderInterface
      */
     private function buildHybridQuery(string $query): array
     {
-        $words = preg_split('/\s+/', $query, -1, PREG_SPLIT_NO_EMPTY);
+        $words = preg_split('/\s+/', $query, -1, PREG_SPLIT_NO_EMPTY) ?: [];
         $hasLongWords = count(array_filter($words, static fn ($w) => mb_strlen($w) >= self::FUZZY_MIN_LENGTH)) > 0;
 
         return [

--- a/src/Search/SearchQueryBuilder.php
+++ b/src/Search/SearchQueryBuilder.php
@@ -25,6 +25,8 @@ final readonly class SearchQueryBuilder implements QueryBuilderInterface
 
     /**
      * Build complete search parameters for Elasticsearch.
+     *
+     * @return array<string, mixed>
      */
     public function build(string $query, SearchStrategy $strategy = SearchStrategy::HYBRID): array
     {
@@ -42,6 +44,10 @@ final readonly class SearchQueryBuilder implements QueryBuilderInterface
 
     /**
      * Build query clause based on strategy.
+     *
+     * @param array<string, mixed> $parsedQuery
+     *
+     * @return array<string, mixed>
      */
     private function buildQuery(string $query, array $parsedQuery, SearchStrategy $strategy): array
     {
@@ -61,6 +67,8 @@ final readonly class SearchQueryBuilder implements QueryBuilderInterface
     /**
      * Hybrid: Exact matches first, fuzzy for long words.
      * Best balance between precision and recall.
+     *
+     * @return array<string, mixed>
      */
     private function buildHybridQuery(string $query): array
     {
@@ -107,6 +115,8 @@ final readonly class SearchQueryBuilder implements QueryBuilderInterface
     /**
      * Exact: No fuzzy matching, exact words only.
      * Best for legal/academic precision.
+     *
+     * @return array<string, mixed>
      */
     private function buildExactQuery(string $query): array
     {
@@ -122,6 +132,8 @@ final readonly class SearchQueryBuilder implements QueryBuilderInterface
     /**
      * Prefix: Match word beginnings with wildcard support.
      * Supports both * (multiple chars) and ? (single char) wildcards.
+     *
+     * @return array<string, mixed>
      */
     private function buildPrefixQuery(string $query): array
     {
@@ -154,6 +166,10 @@ final readonly class SearchQueryBuilder implements QueryBuilderInterface
 
     /**
      * Build structured query from parsed operators.
+     *
+     * @param array<string, mixed> $parsedQuery
+     *
+     * @return array<string, mixed>
      */
     private function buildStructuredQuery(array $parsedQuery): array
     {
@@ -200,6 +216,8 @@ final readonly class SearchQueryBuilder implements QueryBuilderInterface
 
     /**
      * Build highlight configuration.
+     *
+     * @return array<string, mixed>
      */
     private function buildHighlight(): array
     {

--- a/src/Search/SearchQueryBuilder.php
+++ b/src/Search/SearchQueryBuilder.php
@@ -61,6 +61,7 @@ final readonly class SearchQueryBuilder implements QueryBuilderInterface
             SearchStrategy::HYBRID => $this->buildHybridQuery($query),
             SearchStrategy::EXACT => $this->buildExactQuery($query),
             SearchStrategy::PREFIX => $this->buildPrefixQuery($query),
+            default => $this->buildHybridQuery($query),
         };
     }
 

--- a/src/Service/ElasticsearchService.php
+++ b/src/Service/ElasticsearchService.php
@@ -39,6 +39,9 @@ class ElasticsearchService implements IndexManagementInterface, PipelineManageme
         $this->client = $clientBuilder->build();
     }
 
+    /**
+     * @param array<string, mixed> $settings
+     */
     public function createIndex(array $settings = []): void
     {
         $params = [
@@ -134,6 +137,9 @@ class ElasticsearchService implements IndexManagementInterface, PipelineManageme
         $this->client->ingest()->deletePipeline($params);
     }
 
+    /**
+     * @param array<string, mixed> $data
+     */
     public function indexDocument(string $index, string $id, array $data): void
     {
         $this->safeCall(
@@ -175,6 +181,11 @@ class ElasticsearchService implements IndexManagementInterface, PipelineManageme
         $this->indexDocument($this->pdfPagesIndex, $id, $document);
     }
 
+    /**
+     * @param array<string, mixed> $query
+     *
+     * @return array<string, mixed>
+     */
     public function search(array $query): array
     {
         return $this->safeCall(

--- a/src/Service/OllamaEmbeddingService.php
+++ b/src/Service/OllamaEmbeddingService.php
@@ -64,7 +64,7 @@ final readonly class OllamaEmbeddingService implements EmbeddingServiceInterface
             }
         }
 
-        throw new \RuntimeException(sprintf('Failed to generate embedding after %d attempts: %s', self::MAX_RETRIES, $lastException?->getMessage()), 0, $lastException);
+        throw new \RuntimeException(sprintf('Failed to generate embedding after %d attempts: %s', self::MAX_RETRIES, $lastException->getMessage()), 0, $lastException);
     }
 
     public function embedBatch(array $texts): array

--- a/src/Service/PdfProcessor.php
+++ b/src/Service/PdfProcessor.php
@@ -9,6 +9,11 @@ class PdfProcessor
     public function extractPageCount(string $filePath): int
     {
         $pageCountOutput = shell_exec('pdfinfo ' . escapeshellarg($filePath));
+
+        if (!is_string($pageCountOutput)) {
+            return 0;
+        }
+
         preg_match('/Pages:\\s+(\\d+)/i', $pageCountOutput, $matches);
 
         return isset($matches[1]) ? (int) $matches[1] : 0;
@@ -18,6 +23,6 @@ class PdfProcessor
     {
         $text = shell_exec("pdftotext -layout -f $page -l $page " . escapeshellarg($filePath) . ' -');
 
-        return trim($text);
+        return is_string($text) ? trim($text) : '';
     }
 }

--- a/src/Service/ReciprocalRankFusionService.php
+++ b/src/Service/ReciprocalRankFusionService.php
@@ -70,6 +70,11 @@ final readonly class ReciprocalRankFusionService implements RankFusionServiceInt
 
     /**
      * Merge two document objects, combining highlights and preserving best source data.
+     *
+     * @param array<string, mixed> $doc1
+     * @param array<string, mixed> $doc2
+     *
+     * @return array<string, mixed>
      */
     private function mergeDocuments(array $doc1, array $doc2): array
     {

--- a/src/Service/TranslationOrchestrator.php
+++ b/src/Service/TranslationOrchestrator.php
@@ -59,9 +59,9 @@ final class TranslationOrchestrator
             ];
         }
 
-        $pdfFilename = $validation['pdfFilename'];
-        $pageNumber = $validation['pageNumber'];
-        $pdfPath = $validation['pdfPath'];
+        $pdfFilename = (string) $validation['pdfFilename'];
+        $pageNumber = (int) $validation['pageNumber'];
+        $pdfPath = (string) $validation['pdfPath'];
 
         // Extract text from PDF
         $originalText = $this->pdfProcessor->extractTextFromPage($pdfPath, $pageNumber);
@@ -173,9 +173,9 @@ final class TranslationOrchestrator
             ];
         }
 
-        $pdfFilename = $validation['pdfFilename'];
-        $pageNumber = $validation['pageNumber'];
-        $pdfPath = $validation['pdfPath'];
+        $pdfFilename = (string) $validation['pdfFilename'];
+        $pageNumber = (int) $validation['pageNumber'];
+        $pdfPath = (string) $validation['pdfPath'];
 
         // Extract original text
         $originalText = $this->pdfProcessor->extractTextFromPage($pdfPath, $pageNumber);

--- a/src/Service/TranslationOrchestrator.php
+++ b/src/Service/TranslationOrchestrator.php
@@ -6,7 +6,6 @@ namespace App\Service;
 
 use App\Entity\TranslationJob;
 use App\Message\TranslatePageMessage;
-use App\Repository\TranslationJobRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -30,8 +29,7 @@ final class TranslationOrchestrator
         private readonly TranslationRequestValidator $validator,
         private readonly QueueDuplicationChecker $queueChecker,
         private readonly MessageBusInterface $messageBus,
-        private readonly EntityManagerInterface $entityManager,
-        private readonly TranslationJobRepository $jobRepository
+        private readonly EntityManagerInterface $entityManager
     ) {
     }
 

--- a/src/Service/TranslationOrchestrator.php
+++ b/src/Service/TranslationOrchestrator.php
@@ -37,7 +37,7 @@ final class TranslationOrchestrator
      * Request a translation for a PDF page.
      * Returns existing translation if available, otherwise queues for async processing.
      *
-     * @return array{data: array, status_code: int}
+     * @return array{data: array<string, mixed>, status_code: int}
      */
     public function requestTranslation(
         ?string $pdfFilename,
@@ -151,7 +151,7 @@ final class TranslationOrchestrator
      * Check translation status (polling endpoint).
      * Returns translation if ready, or status if still processing.
      *
-     * @return array{data: array, status_code: int}
+     * @return array{data: array<string, mixed>, status_code: int}
      */
     public function checkTranslationStatus(
         ?string $pdfFilename,

--- a/src/Service/TranslationService.php
+++ b/src/Service/TranslationService.php
@@ -171,6 +171,8 @@ class TranslationService
 
     /**
      * Translates text, stores in database and cache.
+     *
+     * @return array{text: string, source: string, source_language: string, cached: bool}
      */
     private function translateAndStore(
         string $pdfFilename,

--- a/symfony.lock
+++ b/symfony.lock
@@ -59,6 +59,15 @@
             "config/packages/http_discovery.yaml"
         ]
     },
+    "phpstan/phpstan": {
+        "version": "2.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "5e490cc197fb6bb1ae22e5abbc531ddc633b6767"
+        }
+    },
     "phpunit/phpunit": {
         "version": "9.6",
         "recipe": {

--- a/tests/Unit/Entity/TranslationJobTest.php
+++ b/tests/Unit/Entity/TranslationJobTest.php
@@ -14,9 +14,9 @@ final class TranslationJobTest extends TestCase
         $job = new TranslationJob();
 
         self::assertNull($job->getId());
-        self::assertNull($job->getPdfFilename());
-        self::assertNull($job->getPageNumber());
-        self::assertNull($job->getTargetLanguage());
+        self::assertSame('', $job->getPdfFilename());
+        self::assertSame(0, $job->getPageNumber());
+        self::assertSame('es', $job->getTargetLanguage());
         self::assertSame('queued', $job->getStatus());
         self::assertInstanceOf(\DateTimeInterface::class, $job->getCreatedAt());
         self::assertNull($job->getStartedAt());


### PR DESCRIPTION
### Added
- **PHPStan Static Analysis**: Level 8 with Symfony and Doctrine extensions
  - `phpstan.neon` config with baseline for gradual adoption (5 remaining errors)
  - CI job `static-analysis` in GitHub Actions pipeline
  - Pre-commit hook integration via Husky
  - `composer phpstan` script and `make phpstan` target

### Fixed
- **PHPStan type safety**: Fix 18 real bugs detected by static analysis
  - Nullsafe operator on guaranteed non-null variable (`OllamaEmbeddingService`)
  - Unused `$jobRepository` dependency (`TranslationOrchestrator`)
  - Missing `instanceof` type guard on `findOneBy()` result (`AnalyticsController`)
  - Unhandled `false` returns from `getmypid()`, `strrpos()`, `preg_split()`, `preg_replace()`, `shell_exec()`
- **PHPStan PHPDoc types**: Add `@param`/`@return` array type annotations across 12 files (36 errors resolved)
  - Contracts, Search builders, Services, Repository, Message classes
- **TranslationJob entity**: Initialize non-nullable DB columns with proper defaults instead of `null`
- **TranslationOrchestrator**: Type-safe casts after validation (resolve 16 nullable chain errors)
- **Dead code removal**: Remove always-true `if ($job)` guard in `TranslatePageMessageHandler`
- **SearchQueryBuilder**: Add default fallback to match expression for unhandled strategies