### PR TITLE
perf(docker): move dev dependency install from build to entrypoint

### DIFF
--- a/.docker/dev/app/Dockerfile
+++ b/.docker/dev/app/Dockerfile
@@ -1,7 +1,6 @@
 # ============================================
-# Development Dockerfile - OPTIMIZED
-# Strategy: Maximum cache reuse + BuildKit
-# Build time: ~30s (vs 2min+ before)
+# Development Dockerfile
+# Strategy: Extensions cached + deps via entrypointd
 # ============================================
 
 # Stage 1: Build PHP extensions (cached indefinitely)
@@ -86,24 +85,6 @@ COPY .docker/dev/php/pcov.ini /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini
 # Copy Supervisor configuration
 COPY .docker/dev/supervisor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
-# Copy dependency manifests first (better cache hit rate)
-COPY composer.json composer.lock ./
-
-# Use BuildKit cache mount for Composer (ultra-fast rebuilds)
-RUN --mount=type=cache,target=/root/.composer/cache \
-    composer install --prefer-dist --no-interaction --no-scripts \
-    && composer dump-autoload --optimize
-
-# Copy Node dependency manifests
-COPY package.json package-lock.json ./
-
-# Use BuildKit cache mount for npm (ultra-fast rebuilds)
-RUN --mount=type=cache,target=/root/.npm \
-    npm install --ignore-scripts
-
-# Copy application files (only rebuilds when code changes)
-COPY . .
-
 # Accept build arguments for user/group IDs (development)
 ARG USER_ID=1000
 ARG GROUP_ID=1000
@@ -111,19 +92,16 @@ ARG GROUP_ID=1000
 # Create user with matching host UID/GID for development
 # This prevents permission issues when VSCode creates files
 RUN if [ "$USER_ID" != "82" ]; then \
-    # Delete existing www-data user
     deluser www-data 2>/dev/null || true; \
-    # Create new www-data with host UID/GID
     addgroup -g ${GROUP_ID} www-data; \
     adduser -D -u ${USER_ID} -G www-data www-data; \
     fi
 
-# Set permissions
-RUN mkdir -p var/cache var/log var/sessions public/pdfs /var/log/supervisor \
-    && chown -R www-data:www-data var public/pdfs \
-    && chmod -R 775 var public/pdfs
+# Entrypoint installs deps on bind-mounted volume at startup
+COPY .docker/dev/app/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
 EXPOSE 9000
 
-# Start Supervisor (manages PHP-FPM + Messenger Worker)
+ENTRYPOINT ["entrypoint.sh"]
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/.docker/dev/app/entrypoint.sh
+++ b/.docker/dev/app/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+# ============================================
+# Development Entrypoint
+# Installs dependencies on bind-mounted volume
+# ============================================
+
+# Install PHP dependencies if missing or outdated
+if [ ! -d "vendor" ] || [ "composer.lock" -nt "vendor/autoload.php" ]; then
+    echo "Installing Composer dependencies..."
+    composer install --prefer-dist --no-interaction
+fi
+
+# Install Node dependencies if missing or outdated
+if [ ! -d "node_modules" ] || [ "package-lock.json" -nt "node_modules/.package-lock.json" ]; then
+    echo "Installing npm dependencies..."
+    npm install --ignore-scripts
+fi
+
+# Create necessary directories
+mkdir -p var/cache var/log var/sessions public/pdfs /var/log/supervisor
+
+# Fix permissions
+chown -R www-data:www-data var public/pdfs 2>/dev/null || true
+chmod -R 775 var public/pdfs 2>/dev/null || true
+
+# Execute CMD (supervisord)
+exec "$@"

--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@ docker-compose*.yml
 !.docker/dev/php/php.ini
 !.docker/dev/php/pcov.ini
 !.docker/dev/supervisor/supervisord.conf
+!.docker/dev/app/entrypoint.sh
 .docker/prod
 !.docker/prod/apache/
 !.docker/prod/supervisor/supervisord.conf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Pre-commit hook integration via Husky
   - `composer phpstan` script and `make phpstan` target
 
+### Changed
+- **Dev Dockerfile**: Remove redundant `COPY` and dependency install steps; bind mount overwrites them
+- **Dev entrypoint**: New `entrypoint.sh` installs Composer/npm deps at startup on bind-mounted volume (skips if up-to-date)
+- **Makefile**: Remove duplicate `composer install` from `_init` (now handled by entrypoint)
+
 ### Fixed
 - **PHPStan type safety**: Fix 18 real bugs detected by static analysis
   - Nullsafe operator on guaranteed non-null variable (`OllamaEmbeddingService`)

--- a/Makefile
+++ b/Makefile
@@ -177,8 +177,6 @@ _wait-for-services: ## Internal: Wait for services to be ready
 	@echo "  $(GREEN)✓ All services ready$(NC)"
 
 _init: ## Internal: Initialize environment
-	@echo "$(BLUE)📦 Installing PHP dependencies...$(NC)"
-	@$(COMPOSE) exec -T php composer install --no-interaction 2>/dev/null || true
 	@echo "$(BLUE)🔧 Running database migrations...$(NC)"
 	@$(COMPOSE) exec -T php php bin/console doctrine:migrations:migrate --no-interaction 2>/dev/null || true
 	@echo "$(BLUE)📨 Setting up Messenger transports...$(NC)"


### PR DESCRIPTION
### Changed
- **Dev Dockerfile**: Remove redundant `COPY` and dependency install steps; bind mount overwrites them
- **Dev entrypoint**: New `entrypoint.sh` installs Composer/npm deps at startup on bind-mounted volume (skips if up-to-date)
- **Makefile**: Remove duplicate `composer install` from `_init` (now handled by entrypoint)