### PR TITLE
Feat/ocr

### DIFF
--- a/.docker/dev/app/Dockerfile
+++ b/.docker/dev/app/Dockerfile
@@ -65,7 +65,7 @@ RUN apk add --no-cache \
     libxml2 \
     oniguruma \
     poppler-utils \
-    tesseract-ocr \
+    ocrmypdf \
     tesseract-ocr-data-eng \
     tesseract-ocr-data-spa \
     tesseract-ocr-data-deu \

--- a/.docker/dev/app/Dockerfile
+++ b/.docker/dev/app/Dockerfile
@@ -65,6 +65,10 @@ RUN apk add --no-cache \
     libxml2 \
     oniguruma \
     poppler-utils \
+    tesseract-ocr \
+    tesseract-ocr-data-eng \
+    tesseract-ocr-data-spa \
+    tesseract-ocr-data-deu \
     git \
     nodejs \
     npm \

--- a/.docker/prod/app/Dockerfile
+++ b/.docker/prod/app/Dockerfile
@@ -18,6 +18,10 @@ RUN apk add --no-cache \
     libxml2 \
     oniguruma \
     poppler-utils \
+    tesseract-ocr \
+    tesseract-ocr-data-eng \
+    tesseract-ocr-data-spa \
+    tesseract-ocr-data-deu \
     supervisor
 
 # Install PHP extensions (build deps removed after)

--- a/.docker/prod/app/Dockerfile
+++ b/.docker/prod/app/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache \
     libxml2 \
     oniguruma \
     poppler-utils \
-    tesseract-ocr \
+    ocrmypdf \
     tesseract-ocr-data-eng \
     tesseract-ocr-data-spa \
     tesseract-ocr-data-deu \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **OCR fallback**: Tesseract OCR for scanned PDFs when `pdftotext` returns insufficient text
+- **OCR text layer**: `ocrmypdf` adds invisible text layer to scanned PDFs during indexing, enabling `pdftotext` extraction and viewer highlights
 - **Semantic similarity threshold**: Configurable kNN `similarity` filter (default: 0.7) to discard irrelevant vector results
 - **Frontend Pagination**: Client-side pagination for search results (10 results per page)
   - `Pagination.vue` component with prev/next, page numbers, and ellipsis navigation
@@ -26,12 +26,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `composer phpstan` script and `make phpstan` target
 
 ### Changed
+- **Viewer highlight system**: Overlay rects from `<mark>` bounding boxes with OCR scale detection for scanned PDFs
+- **Viewer container**: Replaced Tailwind `.container` class with `#pdf-container` to avoid style conflicts
+- **Docker volumes**: `!override` on dev apache/php services to prevent merging with base compose
 - **Dev Dockerfile**: Remove redundant `COPY` and dependency install steps; bind mount overwrites them
 - **Dev entrypoint**: New `entrypoint.sh` installs Composer/npm deps at startup on bind-mounted volume (skips if up-to-date)
 - **Makefile**: Remove duplicate `composer install` from `_init` (now handled by entrypoint)
 - **LanguageDetector**: Align supported languages with frontend (9 → 3: es, en, de)
 
 ### Fixed
+- **Scanned PDF highlights**: Insert virtual spaces between OCR text spans for correct term matching in viewer
+- **pdftotext/pdfinfo stderr**: Suppress `Syntax Warning` output with `2>/dev/null`
 - **PHPStan type safety**: Fix 18 real bugs detected by static analysis
   - Nullsafe operator on guaranteed non-null variable (`OllamaEmbeddingService`)
   - Unused `$jobRepository` dependency (`TranslationOrchestrator`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **OCR fallback**: Tesseract OCR for scanned PDFs when `pdftotext` returns insufficient text
+- **Semantic similarity threshold**: Configurable kNN `similarity` filter (default: 0.7) to discard irrelevant vector results
 - **Frontend Pagination**: Client-side pagination for search results (10 results per page)
   - `Pagination.vue` component with prev/next, page numbers, and ellipsis navigation
   - "Showing 1-10 of 42 results" range display in Controls
@@ -27,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dev Dockerfile**: Remove redundant `COPY` and dependency install steps; bind mount overwrites them
 - **Dev entrypoint**: New `entrypoint.sh` installs Composer/npm deps at startup on bind-mounted volume (skips if up-to-date)
 - **Makefile**: Remove duplicate `composer install` from `_init` (now handled by entrypoint)
+- **LanguageDetector**: Align supported languages with frontend (9 → 3: es, en, de)
 
 ### Fixed
 - **PHPStan type safety**: Fix 18 real bugs detected by static analysis

--- a/TODO.md
+++ b/TODO.md
@@ -53,3 +53,9 @@
 - 🔴 High Priority - Security, production readiness, legal compliance
 - 🟡 Medium Priority - User-facing features, performance improvements
 - 🟢 Low Priority - Nice-to-have features, long-term improvements
+
+
+**Extras**
+- Rector
+- Cache
+- Index and search markdown, text, image 

--- a/assets/styles/pdfViewer.css
+++ b/assets/styles/pdfViewer.css
@@ -1,3 +1,37 @@
+/* PDF Container & Text Layer alignment */
+#pdf-container {
+	position: relative;
+	display: inline-block;
+	padding: 0;
+	margin: 0;
+	line-height: 0;
+}
+
+#pdf-container canvas {
+	display: block;
+}
+
+/* Search Highlight - <mark> is invisible, overlays handle display */
+#pdf-container .textLayer mark {
+	background: transparent;
+	color: transparent;
+	padding: 0;
+	margin: 0;
+}
+
+.highlightLayer {
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	z-index: 2;
+}
+
+.highlight-rect {
+	position: absolute;
+	background: rgba(255, 230, 0, 0.18);
+	border-radius: 2px;
+}
+
 /* Translation Controls */
 .translation-controls {
 	position: fixed;

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.15/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/config/packages/pdf.yaml
+++ b/config/packages/pdf.yaml
@@ -1,0 +1,4 @@
+parameters:
+    # OCR fallback configuration for scanned PDFs
+    pdf.ocr_languages: 'eng+spa+deu'  # Tesseract language packs (must be installed in Docker)
+    pdf.min_text_length: 50  # Minimum chars from pdftotext before trying OCR

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -6,6 +6,7 @@
 parameters:
     elasticsearch.index_pdfs: '%env(ELASTICSEARCH_INDEX_PDFS)%'
     elasticsearch.max_results: '%env(int:ELASTICSEARCH_MAX_RESULTS)%'
+    elasticsearch.semantic_similarity_threshold: 0.7
 
 services:
     # default configuration for services in *this* file
@@ -61,6 +62,7 @@ services:
         arguments:
             $lexicalBuilder: '@App\Search\SearchQueryBuilder'
             $pdfPagesIndex: '%elasticsearch.index_pdfs%'
+            $similarityThreshold: '%elasticsearch.semantic_similarity_threshold%'
 
     # Bind interface to implementation (Dependency Inversion Principle)
     # Using HybridSearchQueryBuilder to support both lexical and semantic search
@@ -100,3 +102,9 @@ services:
     # Rank fusion service for hybrid search
     App\Service\ReciprocalRankFusionService: ~
     App\Contract\RankFusionServiceInterface: '@App\Service\ReciprocalRankFusionService'
+
+    # PDF text extraction with OCR fallback
+    App\Service\PdfProcessor:
+        arguments:
+            $ocrLanguages: '%pdf.ocr_languages%'
+            $minTextLength: '%pdf.min_text_length%'

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,7 +15,7 @@ services:
     image: httpd:2.4.66
     ports:
       - "80:80"
-    volumes:
+    volumes: !override
       - .:/var/www/html
       - ./.docker/dev/apache/apache.conf:/usr/local/apache2/conf/httpd.conf
       - ./.docker/dev/apache/vhost.conf:/usr/local/apache2/conf/extra/httpd-vhosts.conf
@@ -28,7 +28,7 @@ services:
       args:
         USER_ID: ${USER_ID:-1000}
         GROUP_ID: ${GROUP_ID:-1000}
-    volumes:
+    volumes: !override
       - .:/var/www/html
       - ./.docker/dev/php/php.ini:/usr/local/etc/php/php.ini
     environment:

--- a/src/Command/IndexarPdfsCommand.php
+++ b/src/Command/IndexarPdfsCommand.php
@@ -102,6 +102,11 @@ class IndexarPdfsCommand extends Command
                 continue;
             }
 
+            // Add text layer to scanned PDFs (enables viewer highlighting)
+            if ($this->pdfProcessor->ensureTextLayer($path)) {
+                $output->writeln("  <comment>OCR text layer added to {$filename}</comment>");
+            }
+
             for ($page = 1; $page <= $totalPages; ++$page) {
                 $text = $this->pdfProcessor->extractTextFromPage($path, $page);
 

--- a/src/Search/HybridSearchQueryBuilder.php
+++ b/src/Search/HybridSearchQueryBuilder.php
@@ -19,7 +19,8 @@ final readonly class HybridSearchQueryBuilder implements QueryBuilderInterface
         private SearchQueryBuilder $lexicalBuilder,
         private EmbeddingServiceInterface $embeddingService,
         private VectorStoreInterface $vectorStore,
-        private string $pdfPagesIndex
+        private string $pdfPagesIndex,
+        private float $similarityThreshold,
     ) {
     }
 
@@ -54,6 +55,7 @@ final readonly class HybridSearchQueryBuilder implements QueryBuilderInterface
                     'query_vector' => $embedding,
                     'k' => 50,
                     'num_candidates' => 100,
+                    'similarity' => $this->similarityThreshold,
                 ],
                 '_source' => ['title', 'page', 'text', 'path', 'total_pages', 'language', 'date'],
             ],

--- a/src/Service/LanguageDetector.php
+++ b/src/Service/LanguageDetector.php
@@ -16,8 +16,8 @@ class LanguageDetector
 
     public function __construct()
     {
-        // Focus on most common languages for better accuracy
-        $this->detector = new Language(['es', 'en', 'fr', 'pt', 'de', 'it', 'nl', 'pl', 'ru']);
+        // Aligned with frontend supported languages (assets/constants/languages.js)
+        $this->detector = new Language(['es', 'en', 'de']);
     }
 
     /**

--- a/src/Service/PdfProcessor.php
+++ b/src/Service/PdfProcessor.php
@@ -14,7 +14,7 @@ class PdfProcessor
 
     public function extractPageCount(string $filePath): int
     {
-        $pageCountOutput = shell_exec('pdfinfo ' . escapeshellarg($filePath));
+        $pageCountOutput = shell_exec('pdfinfo ' . escapeshellarg($filePath) . ' 2>/dev/null');
 
         if (!is_string($pageCountOutput)) {
             return 0;
@@ -25,17 +25,43 @@ class PdfProcessor
         return isset($matches[1]) ? (int) $matches[1] : 0;
     }
 
+    /**
+     * Adds an invisible text layer to a scanned PDF using ocrmypdf.
+     * After this, pdftotext and PDF.js highlights work normally.
+     */
+    public function ensureTextLayer(string $filePath): bool
+    {
+        $text = $this->extractWithPdftotext($filePath, 1);
+
+        if (strlen($text) >= $this->minTextLength) {
+            return false;
+        }
+
+        $tmpOutput = $filePath . '.ocr.pdf';
+        $exitCode = 0;
+        exec(sprintf(
+            'ocrmypdf --skip-text -l %s %s %s 2>&1',
+            escapeshellarg($this->ocrLanguages),
+            escapeshellarg($filePath),
+            escapeshellarg($tmpOutput)
+        ), $output, $exitCode);
+
+        if ($exitCode === 0 && file_exists($tmpOutput)) {
+            rename($tmpOutput, $filePath);
+
+            return true;
+        }
+
+        if (file_exists($tmpOutput)) {
+            unlink($tmpOutput);
+        }
+
+        return false;
+    }
+
     public function extractTextFromPage(string $filePath, int $page): string
     {
         $text = $this->extractWithPdftotext($filePath, $page);
-
-        if (strlen($text) < $this->minTextLength) {
-            $ocrText = $this->extractWithOcr($filePath, $page);
-
-            if (strlen($ocrText) > strlen($text)) {
-                $text = $ocrText;
-            }
-        }
 
         return $text;
     }
@@ -43,49 +69,12 @@ class PdfProcessor
     private function extractWithPdftotext(string $filePath, int $page): string
     {
         $text = shell_exec(sprintf(
-            'pdftotext -layout -f %d -l %d %s -',
+            'pdftotext -layout -f %d -l %d %s - 2>/dev/null',
             $page,
             $page,
             escapeshellarg($filePath)
         ));
 
         return is_string($text) ? trim($text) : '';
-    }
-
-    private function extractWithOcr(string $filePath, int $page): string
-    {
-        $tmpPrefix = sys_get_temp_dir() . '/ocr_' . getmypid();
-
-        try {
-            // Convert PDF page to PNG image (pdftoppm is from poppler-utils)
-            shell_exec(sprintf(
-                'pdftoppm -f %d -l %d -png -r 300 -singlefile %s %s',
-                $page,
-                $page,
-                escapeshellarg($filePath),
-                escapeshellarg($tmpPrefix)
-            ));
-
-            $imagePath = $tmpPrefix . '.png';
-
-            if (!file_exists($imagePath)) {
-                return '';
-            }
-
-            // Run Tesseract OCR on the image
-            $text = shell_exec(sprintf(
-                'tesseract %s stdout -l %s 2>/dev/null',
-                escapeshellarg($imagePath),
-                $this->ocrLanguages
-            ));
-
-            return is_string($text) ? trim($text) : '';
-        } finally {
-            $imagePath = $tmpPrefix . '.png';
-
-            if (file_exists($imagePath)) {
-                unlink($imagePath);
-            }
-        }
     }
 }

--- a/src/Service/PdfProcessor.php
+++ b/src/Service/PdfProcessor.php
@@ -6,6 +6,12 @@ namespace App\Service;
 
 class PdfProcessor
 {
+    public function __construct(
+        private readonly string $ocrLanguages,
+        private readonly int $minTextLength,
+    ) {
+    }
+
     public function extractPageCount(string $filePath): int
     {
         $pageCountOutput = shell_exec('pdfinfo ' . escapeshellarg($filePath));
@@ -21,8 +27,65 @@ class PdfProcessor
 
     public function extractTextFromPage(string $filePath, int $page): string
     {
-        $text = shell_exec("pdftotext -layout -f $page -l $page " . escapeshellarg($filePath) . ' -');
+        $text = $this->extractWithPdftotext($filePath, $page);
+
+        if (strlen($text) < $this->minTextLength) {
+            $ocrText = $this->extractWithOcr($filePath, $page);
+
+            if (strlen($ocrText) > strlen($text)) {
+                $text = $ocrText;
+            }
+        }
+
+        return $text;
+    }
+
+    private function extractWithPdftotext(string $filePath, int $page): string
+    {
+        $text = shell_exec(sprintf(
+            'pdftotext -layout -f %d -l %d %s -',
+            $page,
+            $page,
+            escapeshellarg($filePath)
+        ));
 
         return is_string($text) ? trim($text) : '';
+    }
+
+    private function extractWithOcr(string $filePath, int $page): string
+    {
+        $tmpPrefix = sys_get_temp_dir() . '/ocr_' . getmypid();
+
+        try {
+            // Convert PDF page to PNG image (pdftoppm is from poppler-utils)
+            shell_exec(sprintf(
+                'pdftoppm -f %d -l %d -png -r 300 -singlefile %s %s',
+                $page,
+                $page,
+                escapeshellarg($filePath),
+                escapeshellarg($tmpPrefix)
+            ));
+
+            $imagePath = $tmpPrefix . '.png';
+
+            if (!file_exists($imagePath)) {
+                return '';
+            }
+
+            // Run Tesseract OCR on the image
+            $text = shell_exec(sprintf(
+                'tesseract %s stdout -l %s 2>/dev/null',
+                escapeshellarg($imagePath),
+                $this->ocrLanguages
+            ));
+
+            return is_string($text) ? trim($text) : '';
+        } finally {
+            $imagePath = $tmpPrefix . '.png';
+
+            if (file_exists($imagePath)) {
+                unlink($imagePath);
+            }
+        }
     }
 }

--- a/templates/pdf/viewer.html.twig
+++ b/templates/pdf/viewer.html.twig
@@ -23,7 +23,7 @@
         <span id="translation-status" class="status-badge"></span>
     </div>
 
-    <div class="container" style="position: relative;">
+    <div id="pdf-container">
         <canvas id="pdf-canvas"></canvas>
         <div id="translation-overlay" style="display: none;"></div>
     </div>

--- a/tests/Unit/Service/LanguageDetectorTest.php
+++ b/tests/Unit/Service/LanguageDetectorTest.php
@@ -41,24 +41,15 @@ final class LanguageDetectorTest extends TestCase
         self::assertIsArray($result['all']);
     }
 
-    public function testDetectFrenchText(): void
+    public function testDetectFrenchTextFallsToSupported(): void
     {
+        // French is not a supported language (only es, en, de)
+        // Detector should return the closest supported language
         $text = 'Ceci est un texte en français avec plusieurs mots pour détecter la langue correctement.';
 
         $result = $this->detector->detect($text);
 
-        self::assertSame('fr', $result['language']);
-        self::assertGreaterThan(0, $result['confidence']);
-    }
-
-    public function testDetectPortugueseText(): void
-    {
-        $text = 'Este é um texto em português brasileiro com muitas palavras específicas como açúcar, coração e também.';
-
-        $result = $this->detector->detect($text);
-
-        // Portuguese and Spanish are very similar, so we check it's one of them
-        self::assertContains($result['language'], ['pt', 'es']);
+        self::assertContains($result['language'], ['es', 'en', 'de']);
         self::assertGreaterThan(0, $result['confidence']);
     }
 

--- a/tests/Unit/Service/PdfProcessorTest.php
+++ b/tests/Unit/Service/PdfProcessorTest.php
@@ -22,7 +22,7 @@ final class PdfProcessorTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->processor = new PdfProcessor();
+        $this->processor = new PdfProcessor('eng+spa+deu', 50);
     }
 
     public function testExtractPageCountParsesValidOutput(): void
@@ -176,7 +176,7 @@ final class PdfProcessorTest extends TestCase
 
     public function testProcessorCanBeInstantiated(): void
     {
-        $processor = new PdfProcessor();
+        $processor = new PdfProcessor('eng+spa+deu', 50);
         $this->assertInstanceOf(PdfProcessor::class, $processor);
     }
 


### PR DESCRIPTION
### Added
- **OCR text layer**: `ocrmypdf` adds invisible text layer to scanned PDFs during indexing, enabling `pdftotext` extraction and viewer highlights
- **Semantic similarity threshold**: Configurable kNN `similarity` filter (default: 0.7) to discard irrelevant vector results

### Changed
- **Viewer highlight system**: Overlay rects from `<mark>` bounding boxes with OCR scale detection for scanned PDFs
- **Viewer container**: Replaced Tailwind `.container` class with `#pdf-container` to avoid style conflicts
- **Docker volumes**: `!override` on dev apache/php services to prevent merging with base compose

### Fixed
- **Scanned PDF highlights**: Insert virtual spaces between OCR text spans for correct term matching in viewer
- **pdftotext/pdfinfo stderr**: Suppress `Syntax Warning` output with `2>/dev/null`