### PR TITLE
build: upgrade Elasticsearch from 9.2.4 to 9.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
     services:
       elasticsearch:
-        image: elasticsearch:9.2.4
+        image: elasticsearch:9.3.0
         env:
           discovery.type: single-node
           xpack.security.enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Changed
+- **Elasticsearch**: 9.2.4 → 9.3.0 (improved kNN early termination, adaptive HNSW, Zstd compression)
+
+---
+
 ## [1.12.0] - 2026-02-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,19 +3,19 @@
 [![Version](https://img.shields.io/badge/Version-1.12.0-blue.svg)](https://github.com/josego85/pdf-content-search)
 [![PHP](https://img.shields.io/badge/PHP-8.4-777BB4?logo=php&logoColor=white)](https://www.php.net/)
 [![Symfony](https://img.shields.io/badge/Symfony-7.4-000000?logo=symfony&logoColor=white)](https://symfony.com/)
-[![Elasticsearch](https://img.shields.io/badge/Elasticsearch-9.2-005571?logo=elasticsearch&logoColor=white)](https://www.elastic.co/)
+[![Elasticsearch](https://img.shields.io/badge/Elasticsearch-9.3-005571?logo=elasticsearch&logoColor=white)](https://www.elastic.co/)
 [![Vue.js](https://img.shields.io/badge/Vue.js-3.5-4FC08D?logo=vue.js&logoColor=white)](https://vuejs.org/)
 [![Ollama](https://img.shields.io/badge/Ollama-AI-000000?logo=ai&logoColor=white)](https://ollama.ai/)
 [![Docker](https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white)](https://www.docker.com/)
 [![Tests](https://img.shields.io/badge/Coverage-87%25-success?logo=phpunit&logoColor=white)](tests/)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL%203.0-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
-AI-powered PDF search with hybrid semantic capabilities using Elasticsearch 9.2 vector search and Ollama embeddings.
+AI-powered PDF search with hybrid semantic capabilities using Elasticsearch 9.3 vector search and Ollama embeddings.
 
 ## Features
 
 - 🧠 **AI Hybrid Search** - Combines keyword matching with semantic understanding (RRF algorithm)
-- 📄 Page-level PDF search with Elasticsearch 9.2 vector search
+- 📄 Page-level PDF search with Elasticsearch 9.3 vector search
 - 🔍 Multiple search modes: Hybrid AI, Exact match, Prefix match
 - 🌍 AI-powered PDF translation (Ollama qwen2.5)
 - 🔄 Async job processing with Symfony Messenger
@@ -72,7 +72,7 @@ docker compose -p pdf-content-search exec php php bin/console app:translation:mo
 ## Stack
 
 - **Backend:** PHP 8.4, Symfony 7.4, PostgreSQL 16
-- **Search:** Elasticsearch 9.2 (vector search, HNSW)
+- **Search:** Elasticsearch 9.3 (vector search, HNSW)
 - **Frontend:** Vue.js 3.5, Tailwind CSS 3.4, PDF.js 5.4, ApexCharts
 - **AI:** Ollama (qwen2.5 translations, nomic-embed-text embeddings)
 - **Queue:** Symfony Messenger (3 workers)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,7 @@ services:
     restart: unless-stopped
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:9.2.4
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.3.0
     environment:
       - discovery.type=single-node
       - cluster.name=docker-cluster

--- a/docs/production.md
+++ b/docs/production.md
@@ -65,7 +65,7 @@ PostgreSQL 16
   ├─ Production database (pdf_search_prod)
   └─ Secure password (auto-generated)
 
-Elasticsearch 9.2
+Elasticsearch 9.3
   ├─ Authentication enabled
   ├─ 512MB JVM heap
   └─ Vector search (768 dimensions)


### PR DESCRIPTION
### Changed
- **Elasticsearch**: 9.2.4 → 9.3.0 (improved kNN early termination, adaptive HNSW, Zstd compression)