### PR TITLE
fix(deps): patch ajv ReDoS vulnerability (GHSA-2g4f-4pwh-qvx6)

### DIFF
--- a/.docker/dev/app/Dockerfile
+++ b/.docker/dev/app/Dockerfile
@@ -4,7 +4,7 @@
 # ============================================
 
 # Stage 1: Build PHP extensions (cached indefinitely)
-FROM php:8.4.17-fpm-alpine AS php-extensions
+FROM php:8.4.18-fpm-alpine AS php-extensions
 
 # Install build + runtime deps in single layer
 RUN apk add --no-cache \
@@ -49,7 +49,7 @@ RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-enable pcov
 
 # Stage 2: Final development image
-FROM php:8.4.17-fpm-alpine
+FROM php:8.4.18-fpm-alpine
 
 # Copy compiled extensions from stage 1 (instant!)
 COPY --from=php-extensions /usr/local/lib/php/extensions/ /usr/local/lib/php/extensions/

--- a/.docker/prod/app/Dockerfile
+++ b/.docker/prod/app/Dockerfile
@@ -6,7 +6,7 @@
 # ============================================
 # Stage 1: Base Image
 # ============================================
-FROM php:8.4.17-fpm-alpine AS base
+FROM php:8.4.18-fpm-alpine AS base
 
 # Install runtime dependencies only
 RUN apk add --no-cache \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Elasticsearch**: 9.2.4 → 9.3.0 (improved kNN early termination, adaptive HNSW, Zstd compression)
+- **Docker Base Images**: Updated to latest stable versions
+  - php: 8.4.17-fpm → 8.4.18-fpm
+
+### Security
+- **ajv**: Patched moderate severity ReDoS vulnerability ([GHSA-2g4f-4pwh-qvx6](https://github.com/advisories/GHSA-2g4f-4pwh-qvx6))
+  - Issue: ReDoS when using the `$data` option in schema validation
+  - ajv: 8.17.1 → 8.18.0
+  - file-loader/node_modules/ajv: 6.12.6 → 6.14.0
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3234,9 +3234,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4522,9 +4522,9 @@
       }
     },
     "node_modules/file-loader/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
### Changed
- **Docker Base Images**: Updated to latest stable versions
  - php: 8.4.17-fpm → 8.4.18-fpm

### Security
- **ajv**: Patched moderate severity ReDoS vulnerability ([GHSA-2g4f-4pwh-qvx6](https://github.com/advisories/GHSA-2g4f-4pwh-qvx6))
  - Issue: ReDoS when using the `$data` option in schema validation
  - ajv: 8.17.1 → 8.18.0
  - file-loader/node_modules/ajv: 6.12.6 → 6.14.0