### PR TITLE
ci(security): harden npm and composer audit jobs

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -32,11 +32,17 @@ jobs:
       - name: Setup Node.js project
         uses: ./.github/actions/setup-node-project
 
-      - name: Run npm audit
+      # Blocks the pipeline — high/critical vulnerabilities must be fixed
+      - name: Run npm audit (high/critical — blocking)
+        run: npm audit --audit-level=high
+
+      # Informational only — moderate issues are reported but do not block
+      - name: Run npm audit (moderate — informational)
         run: npm audit --audit-level=moderate
         continue-on-error: true
 
       - name: Generate audit report
+        if: always()
         run: npm audit --json > npm-audit-report.json || true
 
       - name: Upload audit report
@@ -58,11 +64,13 @@ jobs:
       - name: Setup PHP project
         uses: ./.github/actions/setup-php-project
 
-      - name: Generate audit report
-        run: composer audit --format=json > composer-audit-report.json || true
+      # Blocks the pipeline — any CVE or abandoned package fails the job
+      - name: Run composer audit (blocking)
+        run: composer audit --abandoned=report
 
-      - name: Display audit results
-        run: composer audit
+      - name: Generate audit report
+        if: always()
+        run: composer audit --format=json --abandoned=report > composer-audit-report.json || true
 
       - name: Upload audit report
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI/CD**: Bumped GitHub Actions dependencies
   - `actions/upload-artifact`: 6.0.0 → 7.0.0
   - Added `rector` job to CI pipeline — fails if unapplied Rector changes are detected on push/PR
+  - **Security Audit hardened**: `npm audit` now blocks on `high/critical` (removed `continue-on-error`); moderate kept as informational; `composer audit` runs before report generation with `--abandoned=report` flag
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -10,9 +10,6 @@
   - Command: `app:cleanup-analytics` (cron: daily at 2am)
   - File: `src/Command/CleanupAnalyticsCommand.php`
 
-### Infrastructure
-- [ ] **Composer Security Audit** - Add `composer audit` to CI/CD pipeline
-
 ## 🟡 Medium Priority
 
 ### Analytics Enhancements


### PR DESCRIPTION
### Changed
- **CI/CD**: Bumped GitHub Actions dependencies
  - **Security Audit hardened**: `npm audit` now blocks on `high/critical` (removed `continue-on-error`); moderate kept as informational; `composer audit` runs before report generation with `--abandoned=report` flag