### PR TITLE
feat(analytics): add CSV/JSON export and extract AnalyticsService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Analytics CSV/JSON export**: Contextual export buttons (↓ CSV / ↓ JSON) per dashboard panel (Overview, Trends, Top Queries); non-blocking via native browser download; `GET /api/analytics/export?type=&format=&days=`
+- **`AnalyticsService`**: Extracted all data transformation logic from `AnalyticsController` — date range, metrics formatting, rate computation, and export row building; PHPStan array shapes on public methods
 - **Rector 2.x**: Automated refactoring tooling (`rector.php`) targeting PHP 8.4, Symfony 7.4, and Doctrine ORM 3.x sets; scripts `composer rector` / `composer rector-dry` and `make rector` / `make rector-fix` targets added
 - **Top Search Queries UX**: Paginated table (10/page, 50 loaded from API), sortable columns (Searches ↑↓, Avg Results ↑↓, Click Rate ↑↓), rank medals (gold/silver/bronze) for top 3, mini search volume bars, color-coded click rate badges (0% → gray, ≥50% → green, ≥25% → yellow, <25% → red)
 
 ### Changed
+- **`biome.json`**: Fixed glob `*.vue` → `**/*.vue` (no matcheaba subdirectorios); `noUnusedImports: off` para archivos Vue — elimina la necesidad de `biome-ignore` por import
 - **Rector applied across `src/` and `tests/`**:
   - `empty()` replaced with explicit comparisons (`=== []`, `!== ''`) — eliminates hidden `"0"` edge case
   - `readonly` lifted to class level where all properties are readonly (`LogSearchAnalyticsMessage`, `TranslatePageMessage`, others)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Analytics CSV/JSON export**: Contextual export buttons (↓ CSV / ↓ JSON) per dashboard panel (Overview, Trends, Top Queries); non-blocking via native browser download; `GET /api/analytics/export?type=&format=&days=`
 - **`AnalyticsService`**: Extracted all data transformation logic from `AnalyticsController` — date range, metrics formatting, rate computation, and export row building; PHPStan array shapes on public methods
+- **`AnalyticsServiceTest`**: 11 unit tests covering all public methods — rate calculation, zero-division guard, date grouping, `DateTimeInterface` handling, export row types
 - **Rector 2.x**: Automated refactoring tooling (`rector.php`) targeting PHP 8.4, Symfony 7.4, and Doctrine ORM 3.x sets; scripts `composer rector` / `composer rector-dry` and `make rector` / `make rector-fix` targets added
 - **Top Search Queries UX**: Paginated table (10/page, 50 loaded from API), sortable columns (Searches ↑↓, Avg Results ↑↓, Click Rate ↑↓), rank medals (gold/silver/bronze) for top 3, mini search volume bars, color-coded click rate badges (0% → gray, ≥50% → green, ≥25% → yellow, <25% → red)
 

--- a/TODO.md
+++ b/TODO.md
@@ -19,7 +19,6 @@
   - File: `src/Command/AggregateAnalyticsCommand.php`
 - [ ] **Click Position Heatmap** - Add bar chart component (backend ready)
   - File: `assets/components/analytics/ClickPositionHeatmap.vue`
-- [ ] **Export Analytics Data** - CSV/JSON export for dashboard data
 - [ ] **Filter by Search Strategy** - API endpoint to filter analytics by strategy
 
 ### Performance Optimization

--- a/assets/components/analytics/ExportButtons.vue
+++ b/assets/components/analytics/ExportButtons.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="flex gap-1">
+    <button
+      @click="doExport('csv')"
+      :disabled="exportingFormat !== null"
+      class="text-xs px-2 py-1 border rounded transition-colors disabled:cursor-not-allowed"
+      :class="exportingFormat === 'csv' ? 'text-blue-600 border-blue-300 bg-blue-50' : 'text-gray-500 hover:text-gray-700 border-gray-200 hover:border-gray-300'"
+    >{{ exportingFormat === 'csv' ? '...' : '↓ CSV' }}</button>
+    <button
+      @click="doExport('json')"
+      :disabled="exportingFormat !== null"
+      class="text-xs px-2 py-1 border rounded transition-colors disabled:cursor-not-allowed"
+      :class="exportingFormat === 'json' ? 'text-blue-600 border-blue-300 bg-blue-50' : 'text-gray-500 hover:text-gray-700 border-gray-200 hover:border-gray-300'"
+    >{{ exportingFormat === 'json' ? '...' : '↓ JSON' }}</button>
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue"
+
+const props = defineProps({
+	type: { type: String, required: true },
+	days: { type: [String, Number], required: true },
+})
+
+const exportingFormat = ref(null)
+
+const doExport = (format) => {
+	exportingFormat.value = format
+	const a = document.createElement("a")
+	a.href = `/api/analytics/export?type=${props.type}&format=${format}&days=${props.days}`
+	a.click()
+	setTimeout(() => {
+		exportingFormat.value = null
+	}, 1000)
+}
+</script>

--- a/assets/components/analytics/TopQueriesChart.vue
+++ b/assets/components/analytics/TopQueriesChart.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="bg-white rounded-lg shadow-sm p-6 border border-gray-200">
-    <h3 class="text-lg font-semibold text-gray-900 mb-4">Top Search Queries</h3>
+    <div class="flex items-center justify-between mb-4">
+      <h3 class="text-lg font-semibold text-gray-900">Top Search Queries</h3>
+      <ExportButtons type="top-queries" :days="days" />
+    </div>
 
     <div class="overflow-x-auto">
       <table class="min-w-full divide-y divide-gray-200">
@@ -122,11 +125,12 @@
 
 <script setup>
 import { computed, ref, watch } from "vue"
-// biome-ignore lint/correctness/noUnusedImports: Component used in template
 import Pagination from "../search/Pagination.vue"
+import ExportButtons from "./ExportButtons.vue"
 
 const props = defineProps({
 	data: { type: Array, default: () => [] },
+	days: { type: [String, Number], default: 7 },
 })
 
 const PAGE_SIZE = 10

--- a/assets/components/analytics/TrendsChart.vue
+++ b/assets/components/analytics/TrendsChart.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="bg-white rounded-lg shadow-sm p-6 border border-gray-200">
-    <h3 class="text-lg font-semibold text-gray-900 mb-4">Search Volume Trends</h3>
+    <div class="flex items-center justify-between mb-4">
+      <h3 class="text-lg font-semibold text-gray-900">Search Volume Trends</h3>
+      <ExportButtons type="trends" :days="days" />
+    </div>
     <apexchart
       v-if="chartOptions"
       type="line"
@@ -16,9 +19,11 @@
 
 <script setup>
 import { computed } from "vue"
+import ExportButtons from "./ExportButtons.vue"
 
 const props = defineProps({
 	data: { type: Array, default: () => [] },
+	days: { type: [String, Number], default: 7 },
 })
 
 // biome-ignore lint/correctness/noUnusedVariables: Used in Vue template

--- a/assets/pages/Analytics.vue
+++ b/assets/pages/Analytics.vue
@@ -29,7 +29,12 @@
       <!-- Dashboard Content -->
       <div v-else>
         <!-- KPI Cards -->
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+        <div class="mb-8">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-sm font-medium text-gray-500 uppercase tracking-wide">Overview</h2>
+          <ExportButtons type="overview" :days="selectedPeriod" />
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           <KPICard
             title="Total Searches"
             :value="overview.total_searches"
@@ -53,16 +58,17 @@
             icon="👥"
           />
         </div>
+        </div>
 
         <!-- Charts Row 1 -->
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
-          <TrendsChart :data="trends" />
+          <TrendsChart :data="trends" :days="selectedPeriod" />
           <StrategyDistribution :data="strategyDistribution" />
         </div>
 
         <!-- Charts Row 2 -->
         <div class="grid grid-cols-1 gap-6">
-          <TopQueriesChart :data="topQueries" />
+          <TopQueriesChart :data="topQueries" :days="selectedPeriod" />
         </div>
       </div>
     </div>
@@ -71,13 +77,10 @@
 
 <script setup>
 import { computed, onMounted, ref } from "vue"
-// biome-ignore lint/correctness/noUnusedImports: Components used in template
+import ExportButtons from "../components/analytics/ExportButtons.vue"
 import KPICard from "../components/analytics/KPICard.vue"
-// biome-ignore lint/correctness/noUnusedImports: Components used in template
 import StrategyDistribution from "../components/analytics/StrategyDistribution.vue"
-// biome-ignore lint/correctness/noUnusedImports: Components used in template
 import TopQueriesChart from "../components/analytics/TopQueriesChart.vue"
-// biome-ignore lint/correctness/noUnusedImports: Components used in template
 import TrendsChart from "../components/analytics/TrendsChart.vue"
 
 const isLoading = ref(false)

--- a/biome.json
+++ b/biome.json
@@ -119,7 +119,7 @@
       }
     },
     {
-      "includes": ["*.vue"],
+      "includes": ["**/*.vue"],
       "linter": {
         "rules": {
           "style": {
@@ -127,6 +127,7 @@
             "useTemplate": "warn"
           },
           "correctness": {
+            "noUnusedImports": "off",
             "noUnusedVariables": "warn"
           }
         }

--- a/src/Controller/AnalyticsController.php
+++ b/src/Controller/AnalyticsController.php
@@ -5,15 +5,19 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Repository\SearchAnalyticsRepository;
+use App\Service\AnalyticsService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Attribute\Route;
 
 #[Route(name: 'api_analytics_')]
 final class AnalyticsController extends AbstractController
 {
     public function __construct(
+        private readonly AnalyticsService $analyticsService,
         private readonly SearchAnalyticsRepository $analyticsRepository
     ) {
     }
@@ -22,39 +26,10 @@ final class AnalyticsController extends AbstractController
     public function overview(Request $request): JsonResponse
     {
         $days = (int) $request->query->get('days', 7);
-        $endDate = new \DateTime();
-        $startDate = (clone $endDate)->modify("-{$days} days");
-
-        $metrics = $this->analyticsRepository->getOverviewMetrics($startDate, $endDate);
-
-        // Calculate derived metrics
-        $totalSearches = (int) $metrics['totalSearches'];
-        $clickedSearches = (int) $metrics['clickedSearches'];
-        $zeroResultSearches = (int) $metrics['zeroResultSearches'];
-
-        $clickThroughRate = $totalSearches > 0
-            ? round(($clickedSearches / $totalSearches) * 100, 2)
-            : 0;
-
-        $successRate = $totalSearches > 0
-            ? round((($totalSearches - $zeroResultSearches) / $totalSearches) * 100, 2)
-            : 0;
 
         return new JsonResponse([
             'status' => 'success',
-            'data' => [
-                'total_searches' => $totalSearches,
-                'unique_sessions' => (int) $metrics['uniqueSessions'],
-                'avg_response_time_ms' => round((float) $metrics['avgResponseTime']),
-                'zero_result_searches' => $zeroResultSearches,
-                'click_through_rate' => $clickThroughRate,
-                'success_rate' => $successRate,
-                'period' => [
-                    'start' => $startDate->format('Y-m-d'),
-                    'end' => $endDate->format('Y-m-d'),
-                    'days' => $days,
-                ],
-            ],
+            'data' => $this->analyticsService->getOverview($days),
         ]);
     }
 
@@ -64,30 +39,9 @@ final class AnalyticsController extends AbstractController
         $days = (int) $request->query->get('days', 7);
         $limit = (int) $request->query->get('limit', 20);
 
-        $endDate = new \DateTime();
-        $startDate = (clone $endDate)->modify("-{$days} days");
-
-        $queries = $this->analyticsRepository->getTopQueries($startDate, $endDate, $limit);
-
-        // Format results
-        $formatted = array_map(static function (array $item): array {
-            $searchCount = (int) $item['searchCount'];
-            $clicks = (int) $item['clicks'];
-
-            return [
-                'query' => $item['query'],
-                'search_count' => $searchCount,
-                'avg_results' => round((float) $item['avgResults'], 1),
-                'clicks' => $clicks,
-                'click_rate' => $searchCount > 0
-                    ? round(($clicks / $searchCount) * 100, 1)
-                    : 0,
-            ];
-        }, $queries);
-
         return new JsonResponse([
             'status' => 'success',
-            'data' => $formatted,
+            'data' => $this->analyticsService->getTopQueries($days, $limit),
         ]);
     }
 
@@ -95,37 +49,10 @@ final class AnalyticsController extends AbstractController
     public function trends(Request $request): JsonResponse
     {
         $days = (int) $request->query->get('days', 7);
-        $endDate = new \DateTime();
-        $startDate = (clone $endDate)->modify("-{$days} days");
-
-        $trends = $this->analyticsRepository->getSearchTrends($startDate, $endDate);
-
-        // Group by date and strategy
-        $grouped = [];
-        foreach ($trends as $item) {
-            $date = $item['date'];
-
-            if ($date instanceof \DateTimeInterface) {
-                $date = $date->format('Y-m-d');
-            }
-
-            $strategy = $item['searchStrategy'];
-
-            if (!isset($grouped[$date])) {
-                $grouped[$date] = [
-                    'date' => $date,
-                    'total' => 0,
-                    'by_strategy' => [],
-                ];
-            }
-
-            $grouped[$date]['by_strategy'][$strategy] = (int) $item['searchCount'];
-            $grouped[$date]['total'] += (int) $item['searchCount'];
-        }
 
         return new JsonResponse([
             'status' => 'success',
-            'data' => array_values($grouped),
+            'data' => $this->analyticsService->getTrends($days),
         ]);
     }
 
@@ -154,15 +81,53 @@ final class AnalyticsController extends AbstractController
     {
         $days = (int) $request->query->get('days', 7);
         $limit = (int) $request->query->get('limit', 20);
-
         $endDate = new \DateTime();
         $startDate = (clone $endDate)->modify("-{$days} days");
 
-        $queries = $this->analyticsRepository->getZeroResultQueries($startDate, $endDate, $limit);
-
         return new JsonResponse([
             'status' => 'success',
-            'data' => $queries,
+            'data' => $this->analyticsRepository->getZeroResultQueries($startDate, $endDate, $limit),
+        ]);
+    }
+
+    #[Route('/api/analytics/export', name: 'api_analytics_export', methods: ['GET'])]
+    public function export(Request $request): Response
+    {
+        $days = (int) $request->query->get('days', 7);
+        $type = $request->query->get('type', 'top-queries');
+        $format = $request->query->get('format', 'csv');
+
+        [$rows, $headers] = $this->analyticsService->buildExportRows($type, $days);
+
+        $filename = sprintf('analytics-%s-%dd-%s.%s', $type, $days, date('Y-m-d'), $format);
+
+        if ('json' === $format) {
+            $namedRows = array_map(
+                static fn (array $row): array => array_combine($headers, $row),
+                $rows
+            );
+
+            return new Response(
+                (string) json_encode($namedRows, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_UNICODE),
+                Response::HTTP_OK,
+                [
+                    'Content-Type' => 'application/json',
+                    'Content-Disposition' => 'attachment; filename="' . $filename . '"',
+                ]
+            );
+        }
+
+        return new StreamedResponse(static function () use ($rows, $headers): void {
+            $output = fopen('php://output', 'w');
+            assert($output !== false);
+            fputcsv($output, $headers, escape: '\\');
+            foreach ($rows as $row) {
+                fputcsv($output, $row, escape: '\\');
+            }
+            fclose($output);
+        }, Response::HTTP_OK, [
+            'Content-Type' => 'text/csv; charset=UTF-8',
+            'Content-Disposition' => 'attachment; filename="' . $filename . '"',
         ]);
     }
 
@@ -177,13 +142,8 @@ final class AnalyticsController extends AbstractController
         $pdfPath = $data['pdf_path'] ?? null;
         $page = isset($data['page']) ? (int) $data['page'] : null;
 
-        // Find the most recent search for this session and query
         $analytics = $this->analyticsRepository->findOneBy(
-            [
-                'sessionId' => $sessionId,
-                'query' => $query,
-                'clicked' => false,
-            ],
+            ['sessionId' => $sessionId, 'query' => $query, 'clicked' => false],
             ['createdAt' => 'DESC']
         );
 
@@ -198,15 +158,12 @@ final class AnalyticsController extends AbstractController
 
             $this->analyticsRepository->save($analytics);
 
-            return new JsonResponse([
-                'status' => 'success',
-                'message' => 'Click tracked',
-            ]);
+            return new JsonResponse(['status' => 'success', 'message' => 'Click tracked']);
         }
 
-        return new JsonResponse([
-            'status' => 'error',
-            'message' => 'Search not found',
-        ], \Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND);
+        return new JsonResponse(
+            ['status' => 'error', 'message' => 'Search not found'],
+            Response::HTTP_NOT_FOUND
+        );
     }
 }

--- a/src/Service/AnalyticsService.php
+++ b/src/Service/AnalyticsService.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Repository\SearchAnalyticsRepository;
+
+final readonly class AnalyticsService
+{
+    public function __construct(
+        private SearchAnalyticsRepository $repository
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     total_searches: int,
+     *     unique_sessions: int,
+     *     avg_response_time_ms: float,
+     *     zero_result_searches: int,
+     *     click_through_rate: float|int,
+     *     success_rate: float|int,
+     *     period: array{start: string, end: string, days: int}
+     * }
+     */
+    public function getOverview(int $days): array
+    {
+        [$startDate, $endDate] = $this->dateRange($days);
+        $metrics = $this->repository->getOverviewMetrics($startDate, $endDate);
+
+        $totalSearches = (int) $metrics['totalSearches'];
+        $clickedSearches = (int) $metrics['clickedSearches'];
+        $zeroResultSearches = (int) $metrics['zeroResultSearches'];
+
+        return [
+            'total_searches' => $totalSearches,
+            'unique_sessions' => (int) $metrics['uniqueSessions'],
+            'avg_response_time_ms' => round((float) $metrics['avgResponseTime']),
+            'zero_result_searches' => $zeroResultSearches,
+            'click_through_rate' => $this->rate($clickedSearches, $totalSearches),
+            'success_rate' => $this->rate($totalSearches - $zeroResultSearches, $totalSearches),
+            'period' => [
+                'start' => $startDate->format('Y-m-d'),
+                'end' => $endDate->format('Y-m-d'),
+                'days' => $days,
+            ],
+        ];
+    }
+
+    /** @return list<array{query: string, search_count: int, avg_results: float, clicks: int, click_rate: float|int}> */
+    public function getTopQueries(int $days, int $limit): array
+    {
+        [$startDate, $endDate] = $this->dateRange($days);
+        $queries = $this->repository->getTopQueries($startDate, $endDate, $limit);
+
+        return array_map(static function (array $item): array {
+            $searchCount = (int) $item['searchCount'];
+            $clicks = (int) $item['clicks'];
+
+            return [
+                'query' => $item['query'],
+                'search_count' => $searchCount,
+                'avg_results' => round((float) $item['avgResults'], 1),
+                'clicks' => $clicks,
+                'click_rate' => $searchCount > 0 ? round(($clicks / $searchCount) * 100, 1) : 0,
+            ];
+        }, $queries);
+    }
+
+    /** @return list<array{date: string, total: int, by_strategy: array<string, int>}> */
+    public function getTrends(int $days): array
+    {
+        [$startDate, $endDate] = $this->dateRange($days);
+        $trends = $this->repository->getSearchTrends($startDate, $endDate);
+
+        $grouped = [];
+        foreach ($trends as $item) {
+            $date = $item['date'] instanceof \DateTimeInterface
+                ? $item['date']->format('Y-m-d')
+                : $item['date'];
+
+            if (!isset($grouped[$date])) {
+                $grouped[$date] = ['date' => $date, 'total' => 0, 'by_strategy' => []];
+            }
+
+            $grouped[$date]['by_strategy'][$item['searchStrategy']] = (int) $item['searchCount'];
+            $grouped[$date]['total'] += (int) $item['searchCount'];
+        }
+
+        return array_values($grouped);
+    }
+
+    /** @return array{array<array<int|float|string>>, string[]} */
+    public function buildExportRows(string $type, int $days): array
+    {
+        [$startDate, $endDate] = $this->dateRange($days);
+
+        return match ($type) {
+            'overview' => $this->overviewRows($startDate, $endDate, $days),
+            'trends' => $this->trendsRows($startDate, $endDate),
+            default => $this->topQueriesRows($startDate, $endDate),
+        };
+    }
+
+    /** @return array{\DateTime, \DateTime} */
+    private function dateRange(int $days): array
+    {
+        $endDate = new \DateTime();
+        $startDate = (clone $endDate)->modify("-{$days} days");
+
+        return [$startDate, $endDate];
+    }
+
+    private function rate(int $part, int $total, int $decimals = 2): float|int
+    {
+        return $total > 0 ? round(($part / $total) * 100, $decimals) : 0;
+    }
+
+    /** @return array{array<array<int|float|string>>, string[]} */
+    private function topQueriesRows(\DateTime $startDate, \DateTime $endDate): array
+    {
+        $headers = ['Query', 'Searches', 'Avg Results', 'Clicks', 'Click Rate (%)'];
+        $queries = $this->repository->getTopQueries($startDate, $endDate, 500);
+
+        $rows = array_map(static function (array $item): array {
+            $searchCount = (int) $item['searchCount'];
+            $clicks = (int) $item['clicks'];
+
+            return [
+                $item['query'],
+                $searchCount,
+                round((float) $item['avgResults'], 1),
+                $clicks,
+                $searchCount > 0 ? round(($clicks / $searchCount) * 100, 1) : 0,
+            ];
+        }, $queries);
+
+        return [$rows, $headers];
+    }
+
+    /** @return array{array<array<int|string>>, string[]} */
+    private function trendsRows(\DateTime $startDate, \DateTime $endDate): array
+    {
+        $headers = ['Date', 'Total', 'Hybrid AI', 'Exact', 'Prefix'];
+        $trends = $this->repository->getSearchTrends($startDate, $endDate);
+
+        $grouped = [];
+        foreach ($trends as $item) {
+            $date = $item['date'] instanceof \DateTimeInterface
+                ? $item['date']->format('Y-m-d')
+                : $item['date'];
+
+            if (!isset($grouped[$date])) {
+                $grouped[$date] = ['date' => $date, 'total' => 0, 'hybrid_ai' => 0, 'exact' => 0, 'prefix' => 0];
+            }
+
+            $grouped[$date][$item['searchStrategy']] = (int) $item['searchCount'];
+            $grouped[$date]['total'] += (int) $item['searchCount'];
+        }
+
+        $rows = array_map(
+            static fn (array $d): array => [$d['date'], $d['total'], $d['hybrid_ai'], $d['exact'], $d['prefix']],
+            array_values($grouped)
+        );
+
+        return [$rows, $headers];
+    }
+
+    /** @return array{array<array<int|float|string>>, string[]} */
+    private function overviewRows(\DateTime $startDate, \DateTime $endDate, int $days): array
+    {
+        $headers = ['Metric', 'Value', 'Period'];
+        $metrics = $this->repository->getOverviewMetrics($startDate, $endDate);
+
+        $totalSearches = (int) $metrics['totalSearches'];
+        $clickedSearches = (int) $metrics['clickedSearches'];
+        $zeroResultSearches = (int) $metrics['zeroResultSearches'];
+        $period = sprintf('%s — %s (%d days)', $startDate->format('Y-m-d'), $endDate->format('Y-m-d'), $days);
+
+        $rows = [
+            ['Total Searches', $totalSearches, $period],
+            ['Unique Sessions', (int) $metrics['uniqueSessions'], $period],
+            ['Avg Response Time (ms)', (int) round((float) $metrics['avgResponseTime']), $period],
+            ['Zero Result Searches', $zeroResultSearches, $period],
+            ['Click-Through Rate (%)', $this->rate($clickedSearches, $totalSearches), $period],
+            ['Success Rate (%)', $this->rate($totalSearches - $zeroResultSearches, $totalSearches), $period],
+        ];
+
+        return [$rows, $headers];
+    }
+}

--- a/tests/Functional/Controller/AnalyticsControllerTest.php
+++ b/tests/Functional/Controller/AnalyticsControllerTest.php
@@ -204,6 +204,61 @@ final class AnalyticsControllerTest extends WebTestCase
         $this->assertIsArray($data['data']);
     }
 
+    public function testExportReturnsCsvResponse(): void
+    {
+        $client = self::createClient();
+        $client->request(
+            \Symfony\Component\HttpFoundation\Request::METHOD_GET,
+            '/api/analytics/export',
+            ['type' => 'top-queries', 'format' => 'csv', 'days' => 7]
+        );
+
+        $response = $client->getResponse();
+        $this->skipIfDatabaseNotAvailable($response);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertStringContainsString('text/csv', $response->headers->get('Content-Type'));
+        $this->assertStringContainsString('attachment', $response->headers->get('Content-Disposition'));
+        $this->assertStringContainsString('.csv', $response->headers->get('Content-Disposition'));
+    }
+
+    public function testExportReturnsJsonResponse(): void
+    {
+        $client = self::createClient();
+        $client->request(
+            \Symfony\Component\HttpFoundation\Request::METHOD_GET,
+            '/api/analytics/export',
+            ['type' => 'top-queries', 'format' => 'json', 'days' => 7]
+        );
+
+        $response = $client->getResponse();
+        $this->skipIfDatabaseNotAvailable($response);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertStringContainsString('application/json', $response->headers->get('Content-Type'));
+        $this->assertStringContainsString('.json', $response->headers->get('Content-Disposition'));
+        $this->assertJson($response->getContent());
+    }
+
+    public function testExportAcceptsAllTypes(): void
+    {
+        $client = self::createClient();
+
+        foreach (['overview', 'trends', 'top-queries'] as $type) {
+            $client->request(
+                \Symfony\Component\HttpFoundation\Request::METHOD_GET,
+                '/api/analytics/export',
+                ['type' => $type, 'format' => 'json', 'days' => 7]
+            );
+
+            $response = $client->getResponse();
+            $this->skipIfDatabaseNotAvailable($response);
+
+            $this->assertResponseIsSuccessful();
+            $this->assertStringContainsString($type, $response->headers->get('Content-Disposition'));
+        }
+    }
+
     /**
      * Test track-click endpoint with valid payload.
      */

--- a/tests/Unit/Service/AnalyticsServiceTest.php
+++ b/tests/Unit/Service/AnalyticsServiceTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Repository\SearchAnalyticsRepository;
+use App\Service\AnalyticsService;
+use PHPUnit\Framework\TestCase;
+
+final class AnalyticsServiceTest extends TestCase
+{
+    private SearchAnalyticsRepository&\PHPUnit\Framework\MockObject\MockObject $repository;
+
+    private AnalyticsService $service;
+
+    protected function setUp(): void
+    {
+        $this->repository = $this->createMock(SearchAnalyticsRepository::class);
+        $this->service = new AnalyticsService($this->repository);
+    }
+
+    // -----------------------------------------------------------------------
+    // getOverview
+    // -----------------------------------------------------------------------
+
+    public function testGetOverviewFormatsMetrics(): void
+    {
+        $this->repository->method('getOverviewMetrics')->willReturn([
+            'totalSearches' => '100',
+            'uniqueSessions' => '40',
+            'avgResponseTime' => '250.5',
+            'zeroResultSearches' => '10',
+            'clickedSearches' => '50',
+        ]);
+
+        $result = $this->service->getOverview(7);
+
+        $this->assertSame(100, $result['total_searches']);
+        $this->assertSame(40, $result['unique_sessions']);
+        $this->assertSame(251.0, $result['avg_response_time_ms']);
+        $this->assertSame(10, $result['zero_result_searches']);
+        $this->assertSame(50.0, $result['click_through_rate']);  // 50/100 * 100
+        $this->assertSame(90.0, $result['success_rate']);         // 90/100 * 100
+        $this->assertSame(7, $result['period']['days']);
+    }
+
+    public function testGetOverviewWithZeroSearchesReturnsZeroRates(): void
+    {
+        $this->repository->method('getOverviewMetrics')->willReturn([
+            'totalSearches' => '0',
+            'uniqueSessions' => '0',
+            'avgResponseTime' => '0',
+            'zeroResultSearches' => '0',
+            'clickedSearches' => '0',
+        ]);
+
+        $result = $this->service->getOverview(7);
+
+        $this->assertSame(0, $result['click_through_rate']);
+        $this->assertSame(0, $result['success_rate']);
+    }
+
+    // -----------------------------------------------------------------------
+    // getTopQueries
+    // -----------------------------------------------------------------------
+
+    public function testGetTopQueriesFormatsClickRate(): void
+    {
+        $this->repository->method('getTopQueries')->willReturn([
+            ['query' => 'php', 'searchCount' => '10', 'avgResults' => '5.5', 'clicks' => '3'],
+            ['query' => 'no clicks', 'searchCount' => '5', 'avgResults' => '2.0', 'clicks' => '0'],
+        ]);
+
+        $result = $this->service->getTopQueries(7, 20);
+
+        $this->assertCount(2, $result);
+
+        $this->assertSame('php', $result[0]['query']);
+        $this->assertSame(10, $result[0]['search_count']);
+        $this->assertSame(5.5, $result[0]['avg_results']);
+        $this->assertSame(3, $result[0]['clicks']);
+        $this->assertSame(30.0, $result[0]['click_rate']); // 3/10 * 100
+
+        $this->assertSame(0.0, $result[1]['click_rate']); // round() always returns float
+    }
+
+    public function testGetTopQueriesReturnsEmptyArrayWhenNoData(): void
+    {
+        $this->repository->method('getTopQueries')->willReturn([]);
+
+        $result = $this->service->getTopQueries(7, 20);
+
+        $this->assertSame([], $result);
+    }
+
+    // -----------------------------------------------------------------------
+    // getTrends
+    // -----------------------------------------------------------------------
+
+    public function testGetTrendsGroupsByDateAndStrategy(): void
+    {
+        $this->repository->method('getSearchTrends')->willReturn([
+            ['date' => '2026-01-01', 'searchStrategy' => 'hybrid_ai', 'searchCount' => '5'],
+            ['date' => '2026-01-01', 'searchStrategy' => 'exact', 'searchCount' => '3'],
+            ['date' => '2026-01-02', 'searchStrategy' => 'hybrid_ai', 'searchCount' => '7'],
+        ]);
+
+        $result = $this->service->getTrends(7);
+
+        $this->assertCount(2, $result);
+
+        $this->assertSame('2026-01-01', $result[0]['date']);
+        $this->assertSame(8, $result[0]['total']);
+        $this->assertSame(5, $result[0]['by_strategy']['hybrid_ai']);
+        $this->assertSame(3, $result[0]['by_strategy']['exact']);
+
+        $this->assertSame('2026-01-02', $result[1]['date']);
+        $this->assertSame(7, $result[1]['total']);
+    }
+
+    public function testGetTrendsHandlesDateTimeInterface(): void
+    {
+        $date = new \DateTime('2026-01-01');
+
+        $this->repository->method('getSearchTrends')->willReturn([
+            ['date' => $date, 'searchStrategy' => 'exact', 'searchCount' => '4'],
+        ]);
+
+        $result = $this->service->getTrends(7);
+
+        $this->assertSame('2026-01-01', $result[0]['date']);
+    }
+
+    public function testGetTrendsReturnsEmptyArrayWhenNoData(): void
+    {
+        $this->repository->method('getSearchTrends')->willReturn([]);
+
+        $result = $this->service->getTrends(7);
+
+        $this->assertSame([], $result);
+    }
+
+    // -----------------------------------------------------------------------
+    // buildExportRows
+    // -----------------------------------------------------------------------
+
+    public function testBuildExportRowsTopQueriesType(): void
+    {
+        $this->repository->method('getTopQueries')->willReturn([
+            ['query' => 'test', 'searchCount' => '5', 'avgResults' => '3.0', 'clicks' => '2'],
+        ]);
+
+        [$rows, $headers] = $this->service->buildExportRows('top-queries', 7);
+
+        $this->assertSame(['Query', 'Searches', 'Avg Results', 'Clicks', 'Click Rate (%)'], $headers);
+        $this->assertCount(1, $rows);
+        $this->assertSame('test', $rows[0][0]);
+        $this->assertSame(5, $rows[0][1]);
+    }
+
+    public function testBuildExportRowsTrendsType(): void
+    {
+        $this->repository->method('getSearchTrends')->willReturn([
+            ['date' => '2026-01-01', 'searchStrategy' => 'hybrid_ai', 'searchCount' => '3'],
+        ]);
+
+        [$rows, $headers] = $this->service->buildExportRows('trends', 7);
+
+        $this->assertSame(['Date', 'Total', 'Hybrid AI', 'Exact', 'Prefix'], $headers);
+        $this->assertCount(1, $rows);
+        $this->assertSame('2026-01-01', $rows[0][0]);
+        $this->assertSame(3, $rows[0][1]); // total
+    }
+
+    public function testBuildExportRowsOverviewType(): void
+    {
+        $this->repository->method('getOverviewMetrics')->willReturn([
+            'totalSearches' => '100',
+            'uniqueSessions' => '40',
+            'avgResponseTime' => '250',
+            'zeroResultSearches' => '10',
+            'clickedSearches' => '50',
+        ]);
+
+        [$rows, $headers] = $this->service->buildExportRows('overview', 7);
+
+        $this->assertSame(['Metric', 'Value', 'Period'], $headers);
+        $this->assertCount(6, $rows);
+        $this->assertSame('Total Searches', $rows[0][0]);
+        $this->assertSame(100, $rows[0][1]);
+    }
+
+    public function testBuildExportRowsDefaultsToTopQueries(): void
+    {
+        $this->repository->method('getTopQueries')->willReturn([]);
+
+        [, $headers] = $this->service->buildExportRows('unknown-type', 7);
+
+        $this->assertSame(['Query', 'Searches', 'Avg Results', 'Clicks', 'Click Rate (%)'], $headers);
+    }
+}


### PR DESCRIPTION
### Added
- **Analytics CSV/JSON export**: Contextual export buttons (↓ CSV / ↓ JSON) per dashboard panel (Overview, Trends, Top Queries); non-blocking via native browser download; `GET /api/analytics/export?type=&format=&days=`
- **`AnalyticsService`**: Extracted all data transformation logic from `AnalyticsController` — date range, metrics formatting, rate computation, and export row building; PHPStan array shapes on public methods

### Changed
- **`biome.json`**: Fixed glob `*.vue` → `**/*.vue` (no matcheaba subdirectorios); `noUnusedImports: off` para archivos Vue — elimina la necesidad de `biome-ignore` por import