### PR TITLE
Feat/displayed results count

### DIFF
--- a/.env
+++ b/.env
@@ -47,6 +47,7 @@ ELASTIC_PASSWORD=ignored_in_dev
 ELASTICSEARCH_HOST=http://elasticsearch:9200
 ELASTICSEARCH_INDEX_PDFS=pdf_pages
 ELASTICSEARCH_MAX_RESULTS=100
+SEARCH_PAGE_SIZE=10
 # Production: set strong ELASTIC_PASSWORD in .env.prod.local
 # Production ELASTICSEARCH_HOST: http://elastic:${ELASTIC_PASSWORD}@elasticsearch:9200
 ###< Elasticsearch ###

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,19 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Click Position Distribution chart**: nuevo panel en Analytics Dashboard con CTR% por posición, insights (Position #1 CTR, Top 3 capture) y tooltip con clicks/impresiones
-- **`displayed_results_count`** en `SearchAnalytics`: persiste cuántos resultados se mostraron al usuario (`min(total, pageSize)`) en el momento de la búsqueda — base correcta para calcular impresiones por posición sin depender de configuración futura; incluye migración de schema + data backfill idempotente con `IrreversibleMigration` en `down()`
-- **`SEARCH_PAGE_SIZE`** env var: configura el page size de la UI, inyectado en `AnalyticsCollector` via `services.yaml`
-- **`AnalyticsCollectorTest`**: 4 nuevos tests cubriendo el cálculo de `displayed_results_count` — cap al pageSize, below pageSize, zero results, custom pageSize; mock property tipado con intersection type `MessageBusInterface&MockObject`
-- **Analytics CSV/JSON export**: Contextual export buttons (↓ CSV / ↓ JSON) per dashboard panel (Overview, Trends, Top Queries); non-blocking via native browser download; `GET /api/analytics/export?type=&format=&days=`
-- **`AnalyticsService`**: Extracted all data transformation logic from `AnalyticsController` — date range, metrics formatting, rate computation, and export row building; PHPStan array shapes on public methods
+- **Click Position Distribution chart**: new Analytics Dashboard panel with CTR% per result position, insights (Position #1 CTR, Top 3 capture rate) and tooltip showing clicks/impressions
+- **`displayed_results_count`** in `SearchAnalytics`: persists how many results were shown to the user (`min(total, pageSize)`) at search time — correct basis for impression-based CTR without depending on future config changes; includes schema migration + idempotent data backfill with `IrreversibleMigration` in `down()`
+- **`SEARCH_PAGE_SIZE`** env var: configures UI page size, injected into `AnalyticsCollector` via `services.yaml`
+- **`AnalyticsCollectorTest`**: 4 new tests covering `displayed_results_count` calculation — capped to pageSize, below pageSize, zero results, custom pageSize; mock property typed with intersection type `MessageBusInterface&MockObject`
+- **Analytics CSV/JSON export**: contextual export buttons (↓ CSV / ↓ JSON) per dashboard panel (Overview, Trends, Top Queries); non-blocking via native browser download; `GET /api/analytics/export?type=&format=&days=`
+- **`AnalyticsService`**: extracted all data transformation logic from `AnalyticsController` — date range, metrics formatting, rate computation, and export row building; PHPStan array shapes on public methods
 - **`AnalyticsServiceTest`**: 11 unit tests covering all public methods — rate calculation, zero-division guard, date grouping, `DateTimeInterface` handling, export row types
-- **Rector 2.x**: Automated refactoring tooling (`rector.php`) targeting PHP 8.4, Symfony 7.4, and Doctrine ORM 3.x sets; scripts `composer rector` / `composer rector-dry` and `make rector` / `make rector-fix` targets added
-- **Top Search Queries UX**: Paginated table (10/page, 50 loaded from API), sortable columns (Searches ↑↓, Avg Results ↑↓, Click Rate ↑↓), rank medals (gold/silver/bronze) for top 3, mini search volume bars, color-coded click rate badges (0% → gray, ≥50% → green, ≥25% → yellow, <25% → red)
-- **Docs**: `analytics.md` — Click Position Distribution chart, Data Export section, Top Queries pagination, Data Accuracy (impressions vs total results), IPv6 anonymization; `configuration.md` — `ELASTICSEARCH_MAX_RESULTS` y `SEARCH_PAGE_SIZE`; `README.md` — coverage badge 87% → 93%, analytics feature description actualizada; `TODO.md` — eliminado Click Position Heatmap (implementado)
+- **Rector 2.x**: automated refactoring tooling (`rector.php`) targeting PHP 8.4, Symfony 7.4, and Doctrine ORM 3.x sets; scripts `composer rector` / `composer rector-dry` and `make rector` / `make rector-fix` targets added
+- **Top Search Queries UX**: paginated table (10/page, 50 loaded from API), sortable columns (Searches ↑↓, Avg Results ↑↓, Click Rate ↑↓), rank medals (gold/silver/bronze) for top 3, mini search volume bars, color-coded click rate badges (0% → gray, ≥50% → green, ≥25% → yellow, <25% → red)
+- **Docs**: `analytics.md` — Click Position Distribution chart, Data Export section, Top Queries pagination, Data Accuracy (impressions vs total results), IPv6 anonymization; `configuration.md` — `ELASTICSEARCH_MAX_RESULTS` and `SEARCH_PAGE_SIZE`; `README.md` — coverage badge 87% → 93%, updated analytics feature description; `TODO.md` — removed Click Position Heatmap (implemented)
 
 ### Changed
-- **`biome.json`**: Fixed glob `*.vue` → `**/*.vue` (no matcheaba subdirectorios); `noUnusedImports: off` para archivos Vue — elimina la necesidad de `biome-ignore` por import
+- **`biome.json`**: fixed glob `*.vue` → `**/*.vue` (was not matching subdirectories); `noUnusedImports: off` for Vue files — removes the need for `biome-ignore` comments on imports
 - **Rector applied across `src/` and `tests/`**:
   - `empty()` replaced with explicit comparisons (`=== []`, `!== ''`) — eliminates hidden `"0"` edge case
   - `readonly` lifted to class level where all properties are readonly (`LogSearchAnalyticsMessage`, `TranslatePageMessage`, others)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`AnalyticsServiceTest`**: 11 unit tests covering all public methods — rate calculation, zero-division guard, date grouping, `DateTimeInterface` handling, export row types
 - **Rector 2.x**: Automated refactoring tooling (`rector.php`) targeting PHP 8.4, Symfony 7.4, and Doctrine ORM 3.x sets; scripts `composer rector` / `composer rector-dry` and `make rector` / `make rector-fix` targets added
 - **Top Search Queries UX**: Paginated table (10/page, 50 loaded from API), sortable columns (Searches ↑↓, Avg Results ↑↓, Click Rate ↑↓), rank medals (gold/silver/bronze) for top 3, mini search volume bars, color-coded click rate badges (0% → gray, ≥50% → green, ≥25% → yellow, <25% → red)
+- **Docs**: `analytics.md` — Click Position Distribution chart, Data Export section, Top Queries pagination, Data Accuracy (impressions vs total results), IPv6 anonymization; `configuration.md` — `ELASTICSEARCH_MAX_RESULTS` y `SEARCH_PAGE_SIZE`; `README.md` — coverage badge 87% → 93%, analytics feature description actualizada; `TODO.md` — eliminado Click Position Heatmap (implementado)
 
 ### Changed
 - **`biome.json`**: Fixed glob `*.vue` → `**/*.vue` (no matcheaba subdirectorios); `noUnusedImports: off` para archivos Vue — elimina la necesidad de `biome-ignore` por import

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Click Position Distribution chart**: nuevo panel en Analytics Dashboard con CTR% por posición, insights (Position #1 CTR, Top 3 capture) y tooltip con clicks/impresiones
 - **`displayed_results_count`** en `SearchAnalytics`: persiste cuántos resultados se mostraron al usuario (`min(total, pageSize)`) en el momento de la búsqueda — base correcta para calcular impresiones por posición sin depender de configuración futura; incluye migración de schema + data backfill idempotente con `IrreversibleMigration` en `down()`
 - **`SEARCH_PAGE_SIZE`** env var: configura el page size de la UI, inyectado en `AnalyticsCollector` via `services.yaml`
+- **`AnalyticsCollectorTest`**: 4 nuevos tests cubriendo el cálculo de `displayed_results_count` — cap al pageSize, below pageSize, zero results, custom pageSize; mock property tipado con intersection type `MessageBusInterface&MockObject`
 - **Analytics CSV/JSON export**: Contextual export buttons (↓ CSV / ↓ JSON) per dashboard panel (Overview, Trends, Top Queries); non-blocking via native browser download; `GET /api/analytics/export?type=&format=&days=`
 - **`AnalyticsService`**: Extracted all data transformation logic from `AnalyticsController` — date range, metrics formatting, rate computation, and export row building; PHPStan array shapes on public methods
 - **`AnalyticsServiceTest`**: 11 unit tests covering all public methods — rate calculation, zero-division guard, date grouping, `DateTimeInterface` handling, export row types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Click Position Distribution chart**: nuevo panel en Analytics Dashboard con CTR% por posición, insights (Position #1 CTR, Top 3 capture) y tooltip con clicks/impresiones
+- **`displayed_results_count`** en `SearchAnalytics`: persiste cuántos resultados se mostraron al usuario (`min(total, pageSize)`) en el momento de la búsqueda — base correcta para calcular impresiones por posición sin depender de configuración futura; incluye migración de schema + data backfill idempotente con `IrreversibleMigration` en `down()`
+- **`SEARCH_PAGE_SIZE`** env var: configura el page size de la UI, inyectado en `AnalyticsCollector` via `services.yaml`
 - **Analytics CSV/JSON export**: Contextual export buttons (↓ CSV / ↓ JSON) per dashboard panel (Overview, Trends, Top Queries); non-blocking via native browser download; `GET /api/analytics/export?type=&format=&days=`
 - **`AnalyticsService`**: Extracted all data transformation logic from `AnalyticsController` — date range, metrics formatting, rate computation, and export row building; PHPStan array shapes on public methods
 - **`AnalyticsServiceTest`**: 11 unit tests covering all public methods — rate calculation, zero-division guard, date grouping, `DateTimeInterface` handling, export row types

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Vue.js](https://img.shields.io/badge/Vue.js-3.5-4FC08D?logo=vue.js&logoColor=white)](https://vuejs.org/)
 [![Ollama](https://img.shields.io/badge/Ollama-AI-000000?logo=ai&logoColor=white)](https://ollama.ai/)
 [![Docker](https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white)](https://www.docker.com/)
-[![Tests](https://img.shields.io/badge/Coverage-87%25-success?logo=phpunit&logoColor=white)](tests/)
+[![Tests](https://img.shields.io/badge/Coverage-93%25-success?logo=phpunit&logoColor=white)](tests/)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL%203.0-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
 AI-powered PDF search with hybrid semantic capabilities using Elasticsearch 9.3 vector search and Ollama embeddings.
@@ -19,7 +19,7 @@ AI-powered PDF search with hybrid semantic capabilities using Elasticsearch 9.3 
 - 🔍 Multiple search modes: Hybrid AI, Exact match, Prefix match
 - 🌍 AI-powered PDF translation (Ollama qwen2.5)
 - 🔄 Async job processing with Symfony Messenger
-- 📊 **Analytics Dashboard** - Real-time search metrics with Vue.js + ApexCharts
+- 📊 **Analytics Dashboard** - Real-time search metrics: trends, click position distribution, CTR, CSV/JSON export
 - 📝 **OCR for scanned PDFs** - Automatic text layer via `ocrmypdf` (enables search & highlighting)
 - 📱 Responsive Vue.js frontend with in-PDF highlighting
 
@@ -56,7 +56,7 @@ make prod          # Start production (http://localhost:8080)
 make down          # Stop environment
 make logs          # View logs (add SERVICE=php for specific service)
 make shell         # Open shell in PHP container
-make test          # Run PHPUnit tests (87% coverage)
+make test          # Run PHPUnit tests (93% coverage)
 make status        # Show all environments status
 
 # Translation monitoring (helper scripts)

--- a/TODO.md
+++ b/TODO.md
@@ -17,8 +17,6 @@
   - Command: `app:aggregate-analytics` (cron: daily at 1am)
   - Table: `daily_analytics`
   - File: `src/Command/AggregateAnalyticsCommand.php`
-- [ ] **Click Position Heatmap** - Add bar chart component (backend ready)
-  - File: `assets/components/analytics/ClickPositionHeatmap.vue`
 - [ ] **Filter by Search Strategy** - API endpoint to filter analytics by strategy
 
 ### Performance Optimization

--- a/assets/components/analytics/ClickPositionChart.vue
+++ b/assets/components/analytics/ClickPositionChart.vue
@@ -1,0 +1,75 @@
+<template>
+  <div class="bg-white rounded-lg shadow-sm p-6 border border-gray-200">
+    <div class="flex items-start justify-between mb-1">
+      <h3 class="text-lg font-semibold text-gray-900">Click Position Distribution</h3>
+    </div>
+
+    <template v-if="hasData">
+      <!-- Key insights -->
+      <div class="flex gap-4 text-xs text-gray-500 mb-4">
+        <span>Position #1 CTR: <strong class="text-gray-800">{{ pos1Ctr }}%</strong></span>
+        <span>Top 3 capture: <strong class="text-gray-800">{{ top3Pct }}%</strong> of clicks</span>
+      </div>
+
+      <apexchart type="bar" height="260" :options="chartOptions" :series="series" />
+    </template>
+
+    <div v-else class="h-64 flex items-center justify-center text-gray-500">
+      No click data available
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from "vue"
+
+const props = defineProps({
+	data: { type: Array, default: () => [] },
+})
+
+// biome-ignore lint/correctness/noUnusedVariables: Used in Vue template
+const hasData = computed(() => props.data.length > 0)
+
+// biome-ignore lint/correctness/noUnusedVariables: Used in Vue template
+const pos1Ctr = computed(() => props.data.find((d) => d.position === 1)?.ctr ?? 0)
+
+// biome-ignore lint/correctness/noUnusedVariables: Used in Vue template
+const top3Pct = computed(() => {
+	const total = props.data.reduce((sum, d) => sum + d.clicks, 0)
+	if (total === 0) {
+		return 0
+	}
+	const top3 = props.data.filter((d) => d.position <= 3).reduce((sum, d) => sum + d.clicks, 0)
+	return Math.round((top3 / total) * 100)
+})
+
+// biome-ignore lint/correctness/noUnusedVariables: Used in Vue template
+const series = computed(() => [{ name: "CTR", data: props.data.map((d) => d.ctr) }])
+
+// biome-ignore lint/correctness/noUnusedVariables: Used in Vue template
+const chartOptions = computed(() => ({
+	chart: { type: "bar", toolbar: { show: false } },
+	xaxis: {
+		categories: props.data.map((d) => `#${d.position}`),
+		title: { text: "Result Position" },
+	},
+	yaxis: {
+		title: { text: "CTR %" },
+		min: 0,
+		labels: { formatter: (val) => `${val}%` },
+	},
+	colors: ["#3B82F6"],
+	plotOptions: { bar: { borderRadius: 4, columnWidth: "60%" } },
+	dataLabels: { enabled: false },
+	tooltip: {
+		custom: ({ dataPointIndex }) => {
+			const d = props.data[dataPointIndex]
+			return `<div style="padding:8px 12px;font-size:13px">
+        <div style="font-weight:600;margin-bottom:4px">Position #${d.position}</div>
+        <div>CTR: <strong>${d.ctr}%</strong></div>
+        <div style="color:#6b7280">${d.clicks} clicks / ${d.impressions} impressions</div>
+      </div>`
+		},
+	},
+}))
+</script>

--- a/assets/pages/Analytics.vue
+++ b/assets/pages/Analytics.vue
@@ -67,6 +67,11 @@
         </div>
 
         <!-- Charts Row 2 -->
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+          <ClickPositionChart :data="clickPositions" />
+        </div>
+
+        <!-- Charts Row 3 -->
         <div class="grid grid-cols-1 gap-6">
           <TopQueriesChart :data="topQueries" :days="selectedPeriod" />
         </div>
@@ -77,6 +82,7 @@
 
 <script setup>
 import { computed, onMounted, ref } from "vue"
+import ClickPositionChart from "../components/analytics/ClickPositionChart.vue"
 import ExportButtons from "../components/analytics/ExportButtons.vue"
 import KPICard from "../components/analytics/KPICard.vue"
 import StrategyDistribution from "../components/analytics/StrategyDistribution.vue"
@@ -96,6 +102,7 @@ const overview = ref({
 
 const trends = ref([])
 const topQueries = ref([])
+const clickPositions = ref([])
 
 // biome-ignore lint/correctness/noUnusedVariables: Used in Vue template
 const strategyDistribution = computed(() => {
@@ -118,21 +125,24 @@ const loadData = async () => {
 		const days = selectedPeriod.value
 
 		// Load all data in parallel
-		const [overviewRes, trendsRes, queriesRes] = await Promise.all([
+		const [overviewRes, trendsRes, queriesRes, clickPositionsRes] = await Promise.all([
 			fetch(`/api/analytics/overview?days=${days}`),
 			fetch(`/api/analytics/trends?days=${days}`),
 			fetch(`/api/analytics/top-queries?days=${days}&limit=50`),
+			fetch(`/api/analytics/click-positions?days=${days}`),
 		])
 
-		const [overviewData, trendsData, queriesData] = await Promise.all([
+		const [overviewData, trendsData, queriesData, clickPositionsData] = await Promise.all([
 			overviewRes.json(),
 			trendsRes.json(),
 			queriesRes.json(),
+			clickPositionsRes.json(),
 		])
 
 		overview.value = overviewData.data
 		trends.value = trendsData.data
 		topQueries.value = queriesData.data
+		clickPositions.value = clickPositionsData.data
 	} catch (error) {
 		console.error("Failed to load analytics:", error)
 	} finally {

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -7,6 +7,7 @@ parameters:
     elasticsearch.index_pdfs: '%env(ELASTICSEARCH_INDEX_PDFS)%'
     elasticsearch.max_results: '%env(int:ELASTICSEARCH_MAX_RESULTS)%'
     elasticsearch.semantic_similarity_threshold: 0.7
+    app.search.page_size: '%env(int:SEARCH_PAGE_SIZE)%'
 
 services:
     # default configuration for services in *this* file
@@ -88,6 +89,10 @@ services:
     # Rank fusion service for hybrid search
     App\Service\ReciprocalRankFusionService: ~
     App\Contract\RankFusionServiceInterface: '@App\Service\ReciprocalRankFusionService'
+
+    App\Service\AnalyticsCollector:
+        arguments:
+            $searchPageSize: '%app.search.page_size%'
 
     # PDF text extraction with OCR fallback
     App\Service\PdfProcessor:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,6 +38,7 @@ postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_P
 |----------|-------------|--------------|-------------|
 | `ELASTICSEARCH_HOST` | `http://elasticsearch:9200` | `http://elastic:${ELASTIC_PASSWORD}@elasticsearch:9200` | Elasticsearch URL |
 | `ELASTICSEARCH_INDEX_PDFS` | `pdf_pages` | `pdf_pages` | Index name |
+| `ELASTICSEARCH_MAX_RESULTS` | `100` | `100` | Max results returned per search query |
 | `ELASTIC_PASSWORD` | `ignored_in_dev` | Auto-generated | ES password (prod only) |
 
 **Index settings:**
@@ -59,6 +60,12 @@ postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_P
 - Embeddings: `mxbai-embed-large` (669M dimensions, slower)
 
 **Auto-download:** Models download automatically via healthcheck during `make dev`.
+
+### Analytics
+
+| Variable | Dev Default | Prod Default | Description |
+|----------|-------------|--------------|-------------|
+| `SEARCH_PAGE_SIZE` | `10` | `10` | UI results per page; used by `AnalyticsCollector` to persist `displayed_results_count` (impressions) accurately |
 
 ### Symfony Messenger
 

--- a/docs/features/analytics.md
+++ b/docs/features/analytics.md
@@ -37,7 +37,7 @@ Donut chart visualizing the percentage breakdown of search strategies used.
 **Use case**: Understand which search modes users prefer (AI vs traditional).
 
 #### 3. Top Queries
-Table showing the most popular search terms with metrics:
+Sortable, paginated table showing the most popular search terms with metrics:
 - **Query**: Search term
 - **Searches**: Number of times searched
 - **Avg Results**: Average result count
@@ -46,7 +46,18 @@ Table showing the most popular search terms with metrics:
   - 🟡 Yellow (25-50%): Medium engagement
   - 🔴 Red (<25%): Low engagement
 
+Supports client-side pagination and column sorting. Default: 10 rows per page.
+
 **Use case**: Optimize content for popular queries and improve low-performing terms.
+
+#### 4. Click Position Distribution
+Bar chart showing how often users click each result position (1–10):
+- **Position**: Result rank shown to the user
+- **Clicks**: Number of times that position was clicked
+- **Impressions**: How many times that position was shown (`displayed_results_count`)
+- **CTR**: Click-Through Rate per position (`clicks / impressions × 100`)
+
+**Use case**: Validate result ranking quality. Position 1 should have the highest CTR. A flat distribution indicates poor ranking.
 
 ### 🔍 Time Range Filters
 
@@ -57,6 +68,23 @@ Select the analysis period from the dropdown:
 - **Last 90 days**
 
 Charts and metrics update automatically when changed.
+
+### 📥 Data Export
+
+Each dashboard panel has contextual export buttons:
+
+- **↓ CSV**: Download panel data as a spreadsheet-compatible CSV file
+- **↓ JSON**: Download panel data as structured JSON
+
+**Available export types:** `overview`, `trends`, `top-queries`
+
+```bash
+# Export via API directly
+curl "http://localhost/api/analytics/export?type=overview&format=csv&days=30"
+curl "http://localhost/api/analytics/export?type=top-queries&format=json&days=7"
+```
+
+Exports are non-blocking: the browser downloads the file directly without reloading the page.
 
 ## API Access
 
@@ -119,12 +147,26 @@ curl http://localhost/api/analytics/trends?days=14
 
 **Example**: Hybrid AI: 80% click rate vs Exact: 45% → AI is more effective.
 
+## Data Accuracy
+
+### Impressions vs Total Results
+
+The system distinguishes two counts per search event:
+
+| Field | Value | Used For |
+|-------|-------|----------|
+| `results_count` | Elasticsearch total matches (up to `ELASTICSEARCH_MAX_RESULTS`) | Raw relevance signal |
+| `displayed_results_count` | `min(results_count, SEARCH_PAGE_SIZE)` | Impressions for CTR calculation |
+
+Using `displayed_results_count` ensures CTR is calculated against what the user actually saw — not the full Elasticsearch result set. This is captured at search time, so changing `SEARCH_PAGE_SIZE` later does not corrupt historical data.
+
 ## Data Privacy
 
 All analytics data is **GDPR-compliant**:
-- IP addresses are anonymized (last octet masked)
+- IP addresses are anonymized (last octet zeroed: `192.168.1.100` → `192.168.1.0`)
+- IPv6 anonymized to first 4 groups (`2001:db8:85a3:0000::`)
 - No personal data (emails, names) is stored
-- Session tracking uses hashed, anonymized IPs
+- Session tracking uses Symfony session IDs (no cookies beyond the session)
 
 **Data retention**: 90 days (configurable)
 

--- a/migrations/Version20260304144236.php
+++ b/migrations/Version20260304144236.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260304144236 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE search_analytics ADD displayed_results_count INT DEFAULT NULL');
+        $this->addSql('DROP INDEX idx_75ea56e0e3bd61ce');
+        $this->addSql('DROP INDEX idx_75ea56e0fb7336f0');
+        $this->addSql('DROP INDEX idx_75ea56e016ba31db');
+        $this->addSql('CREATE INDEX IDX_75EA56E0FB7336F0E3BD61CE16BA31DBBF396750 ON messenger_messages (queue_name, available_at, delivered_at, id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP INDEX IDX_75EA56E0FB7336F0E3BD61CE16BA31DBBF396750');
+        $this->addSql('CREATE INDEX idx_75ea56e0e3bd61ce ON messenger_messages (available_at)');
+        $this->addSql('CREATE INDEX idx_75ea56e0fb7336f0 ON messenger_messages (queue_name)');
+        $this->addSql('CREATE INDEX idx_75ea56e016ba31db ON messenger_messages (delivered_at)');
+        $this->addSql('ALTER TABLE search_analytics DROP displayed_results_count');
+    }
+}

--- a/migrations/Version20260304144442.php
+++ b/migrations/Version20260304144442.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\Exception\IrreversibleMigration;
+
+/**
+ * Backfill displayed_results_count for historical rows.
+ *
+ * At the time these rows were recorded the page size was 10,
+ * so we approximate with LEAST(results_count, 10).
+ * New rows will have the exact value set by the application.
+ */
+final class Version20260304144442 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Backfill displayed_results_count for historical search_analytics rows using LEAST(results_count, 10).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('UPDATE search_analytics SET displayed_results_count = LEAST(results_count, 10) WHERE displayed_results_count IS NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        throw new IrreversibleMigration('Data backfill cannot be safely reversed: application-set values cannot be distinguished from backfilled ones.');
+    }
+}

--- a/src/Controller/AnalyticsController.php
+++ b/src/Controller/AnalyticsController.php
@@ -60,19 +60,10 @@ final class AnalyticsController extends AbstractController
     public function clickPositions(Request $request): JsonResponse
     {
         $days = (int) $request->query->get('days', 7);
-        $endDate = new \DateTime();
-        $startDate = (clone $endDate)->modify("-{$days} days");
-
-        $positions = $this->analyticsRepository->getClickPositionDistribution($startDate, $endDate);
-
-        $formatted = array_map(static fn (array $item): array => [
-            'position' => (int) $item['position'],
-            'clicks' => (int) $item['clicks'],
-        ], $positions);
 
         return new JsonResponse([
             'status' => 'success',
-            'data' => $formatted,
+            'data' => $this->analyticsService->getClickPositions($days),
         ]);
     }
 

--- a/src/Entity/SearchAnalytics.php
+++ b/src/Entity/SearchAnalytics.php
@@ -32,6 +32,9 @@ class SearchAnalytics
     #[ORM\Column]
     private int $resultsCount;
 
+    #[ORM\Column(nullable: true)]
+    private ?int $displayedResultsCount = null;
+
     #[ORM\Column]
     private int $responseTimeMs;
 
@@ -116,6 +119,18 @@ class SearchAnalytics
     public function setResultsCount(int $resultsCount): static
     {
         $this->resultsCount = $resultsCount;
+
+        return $this;
+    }
+
+    public function getDisplayedResultsCount(): ?int
+    {
+        return $this->displayedResultsCount;
+    }
+
+    public function setDisplayedResultsCount(int $displayedResultsCount): static
+    {
+        $this->displayedResultsCount = $displayedResultsCount;
 
         return $this;
     }

--- a/src/MessageHandler/LogSearchAnalyticsHandler.php
+++ b/src/MessageHandler/LogSearchAnalyticsHandler.php
@@ -26,6 +26,7 @@ final readonly class LogSearchAnalyticsHandler
         $analytics->setQuery($data['query']);
         $analytics->setSearchStrategy($data['search_strategy'] ?? 'hybrid_ai');
         $analytics->setResultsCount($data['results_count']);
+        $analytics->setDisplayedResultsCount($data['displayed_results_count']);
         $analytics->setResponseTimeMs($data['response_time_ms']);
 
         if (isset($data['user_ip'])) {

--- a/src/Repository/SearchAnalyticsRepository.php
+++ b/src/Repository/SearchAnalyticsRepository.php
@@ -145,6 +145,26 @@ class SearchAnalyticsRepository extends ServiceEntityRepository
     }
 
     /**
+     * Get displayedResultsCount for all searches in range (used to compute impressions per position).
+     *
+     * @return int[]
+     */
+    public function getResultCountsInRange(\DateTime $startDate, \DateTime $endDate): array
+    {
+        $rows = $this->createQueryBuilder('sa')
+            ->select('sa.displayedResultsCount as c')
+            ->where('sa.createdAt >= :startDate')
+            ->andWhere('sa.createdAt <= :endDate')
+            ->andWhere('sa.displayedResultsCount > 0')
+            ->setParameter('startDate', $startDate)
+            ->setParameter('endDate', $endDate)
+            ->getQuery()
+            ->getArrayResult();
+
+        return array_column($rows, 'c');
+    }
+
+    /**
      * Save search analytics entity.
      */
     public function save(SearchAnalytics $entity): void

--- a/src/Service/AnalyticsCollector.php
+++ b/src/Service/AnalyticsCollector.php
@@ -11,7 +11,8 @@ use Symfony\Component\Messenger\MessageBusInterface;
 final readonly class AnalyticsCollector
 {
     public function __construct(
-        private MessageBusInterface $messageBus
+        private MessageBusInterface $messageBus,
+        private int $searchPageSize,
     ) {
     }
 
@@ -40,6 +41,7 @@ final readonly class AnalyticsCollector
             'query' => $query,
             'search_strategy' => $searchStrategy,
             'results_count' => $resultsCount,
+            'displayed_results_count' => min($resultsCount, $this->searchPageSize),
             'response_time_ms' => $responseTimeMs,
             'user_ip' => $request->getClientIp(),
             'user_agent' => $request->headers->get('User-Agent'),

--- a/src/Service/AnalyticsService.php
+++ b/src/Service/AnalyticsService.php
@@ -9,7 +9,7 @@ use App\Repository\SearchAnalyticsRepository;
 final readonly class AnalyticsService
 {
     public function __construct(
-        private SearchAnalyticsRepository $repository
+        private SearchAnalyticsRepository $repository,
     ) {
     }
 
@@ -89,6 +89,50 @@ final readonly class AnalyticsService
         }
 
         return array_values($grouped);
+    }
+
+    /**
+     * @return list<array{position: int, clicks: int, impressions: int, ctr: float}>
+     */
+    public function getClickPositions(int $days, int $maxPosition = 20): array
+    {
+        [$startDate, $endDate] = $this->dateRange($days);
+
+        $rawClicks = $this->repository->getClickPositionDistribution($startDate, $endDate);
+        $resultCounts = $this->repository->getResultCountsInRange($startDate, $endDate);
+
+        $clicksByPosition = [];
+        foreach ($rawClicks as $row) {
+            $clicksByPosition[(int) $row['position']] = (int) $row['clicks'];
+        }
+
+        // Impressions at position P = searches where displayed results >= P.
+        // displayedResultsCount is already capped to page size at collection time.
+        $impressions = array_fill(1, $maxPosition, 0);
+        foreach ($resultCounts as $count) {
+            $cap = min((int) $count, $maxPosition);
+            for ($pos = 1; $pos <= $cap; ++$pos) {
+                ++$impressions[$pos];
+            }
+        }
+
+        $result = [];
+        for ($pos = 1; $pos <= $maxPosition; ++$pos) {
+            $imp = $impressions[$pos];
+
+            if ($imp === 0) {
+                continue;
+            }
+            $clicks = $clicksByPosition[$pos] ?? 0;
+            $result[] = [
+                'position' => $pos,
+                'clicks' => $clicks,
+                'impressions' => $imp,
+                'ctr' => round(($clicks / $imp) * 100, 1),
+            ];
+        }
+
+        return $result;
     }
 
     /** @return array{array<array<int|float|string>>, string[]} */

--- a/tests/Unit/MessageHandler/LogSearchAnalyticsHandlerTest.php
+++ b/tests/Unit/MessageHandler/LogSearchAnalyticsHandlerTest.php
@@ -33,6 +33,7 @@ final class LogSearchAnalyticsHandlerTest extends TestCase
             'query' => 'artificial intelligence',
             'search_strategy' => 'hybrid_ai',
             'results_count' => 15,
+            'displayed_results_count' => 10,
             'response_time_ms' => 120,
             'user_ip' => '192.168.1.100',
             'user_agent' => 'Mozilla/5.0',
@@ -67,6 +68,7 @@ final class LogSearchAnalyticsHandlerTest extends TestCase
             'query' => 'test query',
             'search_strategy' => 'exact',
             'results_count' => 5,
+            'displayed_results_count' => 5,
             'response_time_ms' => 80,
         ];
 
@@ -97,6 +99,7 @@ final class LogSearchAnalyticsHandlerTest extends TestCase
             'session_id' => 'session-789',
             'query' => 'default strategy',
             'results_count' => 10,
+            'displayed_results_count' => 10,
             'response_time_ms' => 100,
         ];
 
@@ -119,6 +122,7 @@ final class LogSearchAnalyticsHandlerTest extends TestCase
             'query' => 'test',
             'search_strategy' => 'hybrid_ai',
             'results_count' => 1,
+            'displayed_results_count' => 1,
             'response_time_ms' => 50,
             'user_ip' => '192.168.1.100',
         ];
@@ -153,6 +157,7 @@ final class LogSearchAnalyticsHandlerTest extends TestCase
                 'query' => 'test',
                 'search_strategy' => 'hybrid_ai',
                 'results_count' => 1,
+                'displayed_results_count' => 1,
                 'response_time_ms' => 50,
                 'user_ip' => $originalIp,
             ];
@@ -181,6 +186,7 @@ final class LogSearchAnalyticsHandlerTest extends TestCase
             'query' => 'test',
             'search_strategy' => 'hybrid_ai',
             'results_count' => 1,
+            'displayed_results_count' => 1,
             'response_time_ms' => 50,
             'user_ip' => '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
         ];
@@ -207,6 +213,7 @@ final class LogSearchAnalyticsHandlerTest extends TestCase
             'query' => 'test',
             'search_strategy' => 'hybrid_ai',
             'results_count' => 1,
+            'displayed_results_count' => 1,
             'response_time_ms' => 50,
             'user_ip' => 'invalid-ip-address',
         ];
@@ -233,6 +240,7 @@ final class LogSearchAnalyticsHandlerTest extends TestCase
             'query' => 'java*',
             'search_strategy' => 'prefix',
             'results_count' => 8,
+            'displayed_results_count' => 8,
             'response_time_ms' => 95,
         ];
 
@@ -256,6 +264,7 @@ final class LogSearchAnalyticsHandlerTest extends TestCase
             'query' => '"artificial intelligence"',
             'search_strategy' => 'exact',
             'results_count' => 3,
+            'displayed_results_count' => 3,
             'response_time_ms' => 110,
         ];
 
@@ -279,6 +288,7 @@ final class LogSearchAnalyticsHandlerTest extends TestCase
             'query' => 'nonexistent term',
             'search_strategy' => 'hybrid_ai',
             'results_count' => 0,
+            'displayed_results_count' => 0,
             'response_time_ms' => 45,
         ];
 

--- a/tests/Unit/Service/AnalyticsCollectorTest.php
+++ b/tests/Unit/Service/AnalyticsCollectorTest.php
@@ -26,7 +26,7 @@ final class AnalyticsCollectorTest extends TestCase
     protected function setUp(): void
     {
         $this->messageBus = $this->createMock(MessageBusInterface::class);
-        $this->analyticsCollector = new AnalyticsCollector($this->messageBus);
+        $this->analyticsCollector = new AnalyticsCollector($this->messageBus, 10);
     }
 
     public function testLogSearchDispatchesMessageForValidQuery(): void

--- a/tests/Unit/Service/AnalyticsCollectorTest.php
+++ b/tests/Unit/Service/AnalyticsCollectorTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
  */
 final class AnalyticsCollectorTest extends TestCase
 {
-    private \PHPUnit\Framework\MockObject\MockObject $messageBus;
+    private MessageBusInterface&\PHPUnit\Framework\MockObject\MockObject $messageBus;
 
     private AnalyticsCollector $analyticsCollector;
 
@@ -292,6 +292,62 @@ final class AnalyticsCollectorTest extends TestCase
             42,
             250
         );
+    }
+
+    public function testDisplayedResultsCountCappedToPageSize(): void
+    {
+        // resultsCount (50) > pageSize (10) → displayed = 10
+        $request = $this->createMockRequest();
+
+        $this->messageBus
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(static fn (LogSearchAnalyticsMessage $message): bool => $message->getData()['displayed_results_count'] === 10))
+            ->willReturn(new Envelope(new \stdClass()));
+
+        $this->analyticsCollector->logSearch($request, 'test', 'hybrid_ai', 50, 100);
+    }
+
+    public function testDisplayedResultsCountEqualsResultsCountWhenBelowPageSize(): void
+    {
+        // resultsCount (3) < pageSize (10) → displayed = 3
+        $request = $this->createMockRequest();
+
+        $this->messageBus
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(static fn (LogSearchAnalyticsMessage $message): bool => $message->getData()['displayed_results_count'] === 3))
+            ->willReturn(new Envelope(new \stdClass()));
+
+        $this->analyticsCollector->logSearch($request, 'test', 'hybrid_ai', 3, 100);
+    }
+
+    public function testDisplayedResultsCountIsZeroWhenNoResults(): void
+    {
+        $request = $this->createMockRequest();
+
+        $this->messageBus
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(static fn (LogSearchAnalyticsMessage $message): bool => $message->getData()['displayed_results_count'] === 0))
+            ->willReturn(new Envelope(new \stdClass()));
+
+        $this->analyticsCollector->logSearch($request, 'test', 'hybrid_ai', 0, 100);
+    }
+
+    public function testDisplayedResultsCountRespectsCustomPageSize(): void
+    {
+        // pageSize = 20, resultsCount = 15 → displayed = 15
+        $collector = new AnalyticsCollector($this->messageBus, 20);
+        $request = $this->createMockRequest();
+
+        $this->messageBus
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(static fn (LogSearchAnalyticsMessage $message): bool => $message->getData()['displayed_results_count'] === 15))
+            ->willReturn(new Envelope(new \stdClass()));
+
+        $collector->logSearch($request, 'test', 'hybrid_ai', 15, 100);
     }
 
     /**


### PR DESCRIPTION
### Added
- **Click Position Distribution chart**: new Analytics Dashboard panel with CTR% per result position, insights (Position #1 CTR, Top 3 capture rate) and tooltip showing clicks/impressions
- **`displayed_results_count`** in `SearchAnalytics`: persists how many results were shown to the user (`min(total, pageSize)`) at search time — correct basis for impression-based CTR without depending on future config changes; includes schema migration + idempotent data backfill with `IrreversibleMigration` in `down()`
- **`SEARCH_PAGE_SIZE`** env var: configures UI page size, injected into `AnalyticsCollector` via `services.yaml`
- **`AnalyticsCollectorTest`**: 4 new tests covering `displayed_results_count` calculation — capped to pageSize, below pageSize, zero results, custom pageSize; mock property typed with intersection type `MessageBusInterface&MockObject`
- **Docs**: `analytics.md` — Click Position Distribution chart, Data Export section, Top Queries pagination, Data Accuracy (impressions vs total results), IPv6 anonymization; `configuration.md` — `ELASTICSEARCH_MAX_RESULTS` and `SEARCH_PAGE_SIZE`; `README.md` — coverage badge 87% → 93%, updated analytics feature description; `TODO.md` — removed Click Position Heatmap (implemented)