### PR TITLE
Chore/claude code hooks

### DIFF
--- a/.claude/commands/new-service.md
+++ b/.claude/commands/new-service.md
@@ -1,0 +1,48 @@
+Create a new service following the project's architecture. The service name and purpose: $ARGUMENTS
+
+Execute these steps in order. Do not skip any.
+
+## Step 1 — Interface in `src/Contract/`
+
+Create `src/Contract/{Name}Interface.php`:
+- `declare(strict_types=1)`
+- `namespace App\Contract`
+- Define only the public methods the service exposes
+- No implementation, no properties
+
+## Step 2 — Service in `src/Service/`
+
+Create `src/Service/{Name}.php`:
+- `declare(strict_types=1)`
+- `namespace App\Service`
+- `implements {Name}Interface`
+- Constructor injection only — never `new` for injected dependencies
+- Use `readonly` properties for injected services
+- Return type declarations on all methods
+- Prefer early returns over nested conditionals
+
+## Step 3 — DI binding in `config/services.yaml`
+
+Add under `services:`:
+```yaml
+App\Contract\{Name}Interface:
+    class: App\Service\{Name}
+```
+
+## Step 4 — Unit test in `tests/Unit/Service/`
+
+Create `tests/Unit/Service/{Name}Test.php`:
+- `declare(strict_types=1)`
+- `namespace App\Tests\Unit\Service`
+- Extends `PHPUnit\Framework\TestCase`
+- Mock interfaces, never concrete classes
+- Test the public methods defined in the interface
+- At minimum: one test per public method
+
+## Verification
+
+After all 4 files are created, confirm:
+- [ ] Interface exists in `src/Contract/`
+- [ ] Service `implements` the interface
+- [ ] DI binding added to `config/services.yaml`
+- [ ] Unit test file exists in `tests/Unit/Service/`

--- a/.claude/commands/quality-check.md
+++ b/.claude/commands/quality-check.md
@@ -1,0 +1,40 @@
+Run all quality checks and report results. Stop on first failure and explain how to fix it.
+
+## Step 1 — PHPStan (static analysis)
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml exec -T php composer phpstan
+```
+
+If it fails: show the errors. Do not proceed to next step.
+
+## Step 2 — PHP-CS-Fixer (code style)
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml exec -T php composer cs-check
+```
+
+If it fails: run `composer cs-fix` to fix automatically, then show what changed.
+
+## Step 3 — Rector (modernization)
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml exec -T php composer rector-dry
+```
+
+If it finds changes: show them and ask the user whether to apply with `composer rector`.
+
+## Step 4 — Biome (JS/Vue)
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml exec -T php npm run lint
+```
+
+If it fails: show the errors and their locations.
+
+## Summary
+
+After all steps, report:
+- ✅ Pass or ❌ Fail for each tool
+- Total issues found
+- Recommended next action

--- a/.claude/commands/security-audit.md
+++ b/.claude/commands/security-audit.md
@@ -1,0 +1,24 @@
+Run security audits on PHP and JS dependencies. Stop on first failure and explain how to fix it.
+
+## Step 1 — Composer audit (PHP)
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml exec -T php composer audit
+```
+
+If it fails: show the affected package, CVE ID, severity, and recommended version to upgrade to.
+
+## Step 2 — npm audit (JS)
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml exec -T php npm audit --audit-level=high
+```
+
+If it fails: show the affected package, vulnerability type, severity, and run `npm audit fix` if safe to do so.
+
+## Summary
+
+After both steps, report:
+- ✅ Pass or ❌ Fail for each tool
+- Total vulnerabilities found by severity (critical / high / moderate)
+- Recommended next action

--- a/.claude/hooks/auto-format.sh
+++ b/.claude/hooks/auto-format.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Auto-format files after Claude edits them.
+# Runs php-cs-fixer (via Docker) for PHP, Biome for JS/Vue/TS.
+# Always exits 0 — never blocks Claude if tooling is unavailable.
+
+FILE=$(jq -r '.tool_input.file_path // empty' 2>/dev/null)
+
+[[ -z "$FILE" ]] && exit 0
+
+PROJECT_ROOT="$(pwd)"
+RELATIVE="${FILE#"$PROJECT_ROOT/"}"
+
+case "$FILE" in
+    *.php)
+        docker compose -f docker-compose.yml -f docker-compose.dev.yml \
+            exec -T php vendor/bin/php-cs-fixer fix "$RELATIVE" \
+            --quiet --no-interaction 2>/dev/null
+        ;;
+    *.vue | *.js | *.ts)
+        npx biome format --write "$FILE" --quiet 2>/dev/null
+        ;;
+esac
+
+exit 0

--- a/.claude/hooks/protect-secret-files.sh
+++ b/.claude/hooks/protect-secret-files.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Blocks Claude from reading gitignored env files via Read or Grep.
+# Gitignored = contains real secrets (.env.local, .env.prod.local, etc.)
+# Committed env files (.env) are safe — no real secrets by convention.
+
+# Read uses file_path; Grep uses path
+FILE=$(jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
+
+[[ -z "$FILE" ]] && exit 0
+[[ ! "$FILE" == *.env* ]] && exit 0
+
+if git check-ignore -q "$FILE" 2>/dev/null; then
+    echo "HOOK BLOCKED: $(basename "$FILE") is gitignored and may contain real secrets."
+    echo "Do not read secret files. Ask the user which variables are needed instead."
+    exit 2
+fi
+
+exit 0

--- a/.claude/hooks/validate-service-interface.sh
+++ b/.claude/hooks/validate-service-interface.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Warns when a new Service class doesn't implement a Contract interface.
+# Runs after Write — new file creation only.
+# Outputs to stdout so Claude sees the warning and can self-correct.
+
+FILE=$(jq -r '.tool_input.file_path // empty' 2>/dev/null)
+
+[[ -z "$FILE" ]] && exit 0
+[[ "$FILE" != */src/Service/*.php ]] && exit 0
+[[ ! -f "$FILE" ]] && exit 0
+
+# Skip non-concrete classes
+grep -qE '^\s*(interface|trait|enum|abstract class)' "$FILE" && exit 0
+
+if ! grep -qE 'class\s+\w+.*\bimplements\b' "$FILE"; then
+    CLASS=$(grep -oE 'class\s+\w+' "$FILE" | head -1 | awk '{print $2}')
+    echo "HOOK WARNING: ${CLASS} in src/Service/ does not implement any interface."
+    echo "Add a contract in src/Contract/ per CLAUDE.md architecture rules (Interface/Contract Pattern)."
+fi
+
+exit 0

--- a/.claude/hooks/validate-strict-types.sh
+++ b/.claude/hooks/validate-strict-types.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Warns when a new PHP file is missing declare(strict_types=1).
+# Required in every PHP file per CLAUDE.md coding standards.
+
+FILE=$(jq -r '.tool_input.file_path // empty' 2>/dev/null)
+
+[[ -z "$FILE" ]] && exit 0
+[[ "$FILE" != *.php ]] && exit 0
+[[ ! -f "$FILE" ]] && exit 0
+
+if ! grep -q 'declare(strict_types=1)' "$FILE"; then
+    echo "HOOK WARNING: $(basename "$FILE") is missing declare(strict_types=1)."
+    echo "Required in every PHP file per CLAUDE.md coding standards."
+fi
+
+exit 0

--- a/.claude/hooks/validate-test-exists.sh
+++ b/.claude/hooks/validate-test-exists.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Warns when a new Service class has no corresponding Unit test.
+# Every new service must have a Unit test per CLAUDE.md testing rules.
+
+FILE=$(jq -r '.tool_input.file_path // empty' 2>/dev/null)
+
+[[ -z "$FILE" ]] && exit 0
+[[ "$FILE" != */src/Service/*.php ]] && exit 0
+[[ ! -f "$FILE" ]] && exit 0
+
+grep -qE '^\s*(interface|trait|enum|abstract class)' "$FILE" && exit 0
+
+BASENAME=$(basename "$FILE" .php)
+TEST_FILE="tests/Unit/Service/${BASENAME}Test.php"
+
+if [[ ! -f "$TEST_FILE" ]]; then
+    echo "HOOK WARNING: No unit test found for ${BASENAME}."
+    echo "Expected: ${TEST_FILE}"
+    echo "Every new service must have a Unit test per CLAUDE.md testing rules."
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,61 @@
 {
   "enabledPlugins": {
     "planning-with-files@planning-with-files": true
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read|Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/protect-secret-files.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/auto-format.sh",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/validate-service-interface.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/validate-strict-types.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/validate-test-exists.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **SEO meta layer** (`base.html.twig`): `<title>`, `<meta description>`, `<meta robots>`, `<link rel="canonical">` (Symfony router), Open Graph tags, JSON-LD `WebSite + SearchAction` structured data — all overridable per page
 - **Accessibility**: skip-to-content link (`sr-only` + `focus:not-sr-only` pattern); `<main id="main-content">` landmark; ARIA combobox pattern on search input (`role`, `aria-expanded`, `aria-haspopup`, `aria-controls`, `aria-activedescendant`)
 - **`prod entrypoint`** (`.docker/prod/app/entrypoint.sh`): runs DB migrations, sets up Messenger transport, and warms Symfony cache automatically on every container start — idempotent; no manual post-deploy steps required
+- **Claude Code hooks** (`.claude/hooks/`): `protect-secret-files.sh` blocks reading gitignored `.env*` files via `Read`/`Grep`; `auto-format.sh` runs PHP-CS-Fixer or Biome after every edit; `validate-service-interface.sh` warns when a new service has no contract; `validate-strict-types.sh` warns when `declare(strict_types=1)` is missing; `validate-test-exists.sh` warns when a new service has no unit test
+- **Claude Code slash commands** (`.claude/commands/`): `/new-service` guides interface + service + DI binding + unit test creation; `/quality-check` runs PHPStan, PHP-CS-Fixer, Rector and Biome in sequence; `/security-audit` runs `composer audit` and `npm audit`
 
 ### Changed
 - **`PdfProcessor`**: replaced `exec()`/`shell_exec()` with `Symfony\Component\Process\Process` — args passed as array (no shell interpolation, eliminates injection surface), explicit 300 s timeout on `ocrmypdf`, clean `isSuccessful()` / `getExitCode()` checks, stderr no longer silently discarded
@@ -33,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Skip link URL pollution**: replaced `-translate-y-full` with `sr-only`/`focus:not-sr-only` — prevents `#main-content` from appearing in the address bar on accidental click; element is now fully clipped from the DOM until keyboard focus
 - **`AnalyticsController::trackClick()`**: corrected `time_to_click_ms` calculation — was `microtime(true)*1000 - getTimestamp()*1000` (wrong units); now `(microtime(true) - getTimestamp()) * 1000`; corrupted all stored click-latency values
 - **`TranslationController`**: JSON body guard — returns `400 Bad Request` when `json_decode` produces a non-array instead of silently passing `null` fields to the orchestrator
+- **`biome.json`**: excluded `.claude/**` from Biome scope to prevent false formatter errors on local settings files
 
 ### Removed
 - **`bin/download-models.sh`**: deleted — model provisioning moved into the container entrypoint; `make dev`/`make prod` no longer require a separate download step

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -523,6 +523,49 @@ Analytics must be auto-deleted after 90 days. This is not yet implemented (see T
 
 ---
 
+## Claude Code Hooks
+
+Hooks in `.claude/hooks/` run automatically on every Claude Code session. Do not work around them — they enforce project standards.
+
+### Active Hooks
+
+| Hook | Event | Trigger | Purpose |
+|---|---|---|---|
+| `protect-secret-files.sh` | `PreToolUse` Read\|Grep | Any `.env*` file that is gitignored | Blocks reading files that may contain real secrets — ask the user for the specific values needed instead |
+| `auto-format.sh` | `PostToolUse` Edit\|Write | Any `.php`, `.vue`, `.js`, `.ts` file | Runs `php-cs-fixer` (via Docker) or `biome format` automatically |
+| `validate-service-interface.sh` | `PostToolUse` Write | New file in `src/Service/` | Warns if a concrete class does not `implement` a contract from `src/Contract/` |
+| `validate-strict-types.sh` | `PostToolUse` Write | Any new `.php` file | Warns if `declare(strict_types=1)` is missing |
+| `validate-test-exists.sh` | `PostToolUse` Write | New file in `src/Service/` | Warns if no corresponding `tests/Unit/Service/*Test.php` exists |
+
+### Hook Output
+
+- Hooks that output to **stdout** inject feedback directly into Claude's context — Claude will self-correct without user intervention.
+- Hooks that exit with code **2** block the operation entirely (`protect-secret-files.sh`).
+- All validation hooks exit **0** — they warn but never block.
+
+### Secret File Protection
+
+Never attempt to read `.env.local`, `.env.prod`, `.env.prod.local`, or any other gitignored env file. The hook will block the read and instruct you to ask the user for the specific variable values needed.
+
+---
+
+## Slash Commands
+
+Custom slash commands in `.claude/commands/`. Invoke them by typing `/command-name` in Claude Code.
+
+| Command | File | Purpose |
+|---|---|---|
+| `/new-service` | `new-service.md` | Creates interface + service + DI binding + unit test in one guided flow |
+| `/quality-check` | `quality-check.md` | Runs PHPStan → PHP-CS-Fixer → Rector → Biome in sequence; stops on first failure |
+| `/security-audit` | `security-audit.md` | Runs `composer audit` + `npm audit`; reports vulnerabilities by severity |
+
+### Usage Notes
+- `/new-service` accepts arguments: `/new-service ReportExporter - exports analytics as PDF`
+- `/quality-check` and `/security-audit` require the Docker stack to be running (`make dev`)
+- Both PHP tools run inside the `php` container; Biome also runs inside the container via `npm run lint`
+
+---
+
 ## Common Pitfalls to Avoid
 
 1. **Adding new services without interfaces** — all services must implement a contract in `src/Contract/`

--- a/assets/components/analytics/ExportButtons.vue
+++ b/assets/components/analytics/ExportButtons.vue
@@ -25,6 +25,7 @@ const props = defineProps({
 
 const exportingFormat = ref(null)
 
+// biome-ignore lint/correctness/noUnusedVariables: used in template via @click
 const doExport = (format) => {
 	exportingFormat.value = format
 	const a = document.createElement("a")

--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,8 @@
     "defaultBranch": "main"
   },
   "files": {
-    "ignoreUnknown": false
+    "ignoreUnknown": false,
+    "includes": ["**", "!.claude/**"]
   },
   "formatter": {
     "enabled": true,
@@ -67,7 +68,8 @@
         "noDoubleEquals": "error",
         "noExplicitAny": "off",
         "noShadowRestrictedNames": "off",
-        "useAwait": "error"
+        "useAwait": "error",
+        "useBiomeIgnoreFolder": "off"
       },
       "nursery": {
         "useSortedClasses": "off"


### PR DESCRIPTION
## Added
- **Claude Code hooks** (`.claude/hooks/`): `protect-secret-files.sh` blocks reading gitignored `.env*` files via `Read`/`Grep`; `auto-format.sh` runs PHP-CS-Fixer or Biome after every edit; `validate-service-interface.sh` warns when a new service has no contract; `validate-strict-types.sh` warns when `declare(strict_types=1)` is missing; `validate-test-exists.sh` warns when a new service has no unit test
- **Claude Code slash commands** (`.claude/commands/`): `/new-service` guides interface + service + DI binding + unit test creation; `/quality-check` runs PHPStan, PHP-CS-Fixer, Rector and Biome in sequence; `/security-audit` runs `composer audit` and `npm audit`

### Changed
- **`biome.json`**: excluded `.claude/**` from Biome scope to prevent false formatter errors on local settings files