### PR TITLE
chore: pin Docker base images to SHA digests and bump php to 8.4.19

### DIFF
--- a/.docker/dev/app/Dockerfile
+++ b/.docker/dev/app/Dockerfile
@@ -4,7 +4,7 @@
 # ============================================
 
 # Stage 1: Build PHP extensions (cached indefinitely)
-FROM php:8.4.18-fpm-alpine AS php-extensions
+FROM php:8.4.19-fpm-alpine@sha256:38c3275e8d8fe1b395dd81dccdbdbec6b0fa1fa318e2391c4ad98eae3b6dc0e3 AS php-extensions
 
 # Install build + runtime deps in single layer
 RUN apk add --no-cache \
@@ -49,7 +49,7 @@ RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-enable pcov
 
 # Stage 2: Final development image
-FROM php:8.4.18-fpm-alpine
+FROM php:8.4.19-fpm-alpine@sha256:38c3275e8d8fe1b395dd81dccdbdbec6b0fa1fa318e2391c4ad98eae3b6dc0e3
 
 # Copy compiled extensions from stage 1 (instant!)
 COPY --from=php-extensions /usr/local/lib/php/extensions/ /usr/local/lib/php/extensions/

--- a/.docker/dev/app/entrypoint.sh
+++ b/.docker/dev/app/entrypoint.sh
@@ -15,7 +15,7 @@ fi
 # Install Node dependencies if missing or outdated
 if [ ! -d "node_modules" ] || [ "package-lock.json" -nt "node_modules/.package-lock.json" ]; then
     echo "Installing npm dependencies..."
-    npm install --ignore-scripts
+    npm ci --ignore-scripts
 fi
 
 # Create necessary directories

--- a/.docker/ollama/Dockerfile
+++ b/.docker/ollama/Dockerfile
@@ -1,4 +1,6 @@
-FROM ollama/ollama:latest
+# Vulnerabilities reported are in the Ubuntu 24.04 base — no upstream fix available in 0.18.0 (latest).
+# Pin to SHA for supply-chain integrity; upgrade when a patched release is available.
+FROM ollama/ollama:0.18.0@sha256:e23e6499890325d31f3454cdc83f7a613a2423c8a9e167bbafea0b0e3c27d7c6
 
 COPY .docker/ollama/entrypoint.sh /entrypoint.sh
 

--- a/.docker/prod/app/Dockerfile
+++ b/.docker/prod/app/Dockerfile
@@ -6,7 +6,7 @@
 # ============================================
 # Stage 1: Base Image
 # ============================================
-FROM php:8.4.18-fpm-alpine AS base
+FROM php:8.4.19-fpm-alpine@sha256:38c3275e8d8fe1b395dd81dccdbdbec6b0fa1fa318e2391c4ad98eae3b6dc0e3 AS base
 
 # Install runtime dependencies only
 RUN apk add --no-cache \
@@ -49,7 +49,7 @@ WORKDIR /var/www/html
 # ============================================
 # Stage 2: Node Builder - Compile assets
 # ============================================
-FROM node:24-alpine AS node-builder
+FROM node:24-alpine@sha256:7fddd9ddeae8196abf4a3ef2de34e11f7b1a722119f91f28ddf1e99dcafdf114 AS node-builder
 
 WORKDIR /build
 
@@ -66,7 +66,7 @@ RUN npm run build
 # ============================================
 # Stage 3: Composer Builder - PHP dependencies
 # ============================================
-FROM composer:latest AS composer-builder
+FROM composer:latest@sha256:743aebe48ca67097c36819040633ea77e44a561eca135e4fc84c002e63a1ba07 AS composer-builder
 
 WORKDIR /build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CodeQL**: SAST covers JavaScript/TypeScript frontend; PHP not supported by the current pinned action version (`codeql-action` v4.32.6)
 - **Token permissions hardened** (`codeql.yml`, `security-audit.yml`): moved from workflow-level to job-level `permissions` with `read-all` default; each job declares only the permissions it needs (principle of least privilege)
 - **`ossf/scorecard-action`** pinned to commit SHA (`05b42c6`) — was the only unpinned action in the repo; now consistent with all other `uses:` references
+- **Docker base images pinned to SHA digest**: `php:8.4.18` → `8.4.19` (security patch) + SHA pinned in dev and prod Dockerfiles; `node:24-alpine`, `composer:latest`, `ollama/ollama:0.18.0` pinned to manifest list SHA — eliminates mutable tag risk
+- **`npm install` → `npm ci`** in dev `entrypoint.sh` — reproducible installs using exact lockfile; eliminates non-deterministic dependency resolution
 - **OpenSSF Scorecard** (`scorecard.yml`): added GitHub Actions workflow — runs on push to `main` and weekly; publishes score to scorecard.dev; uploads SARIF findings to the GitHub Security tab; scoped to `main` only to avoid exposing `id-token: write` on fork PRs
 - **`github/codeql-action`** (4.32.4 → 4.32.6): patched CodeQL SAST action — applies upstream security and reliability fixes to the static analysis workflow
 - **`actions/dependency-review-action`** (4.8.3 → 4.9.0): updated dependency review action — improved vulnerability detection coverage for PR dependency diffs


### PR DESCRIPTION
### Security
- **Docker base images pinned to SHA digest**: `php:8.4.18` → `8.4.19` (security patch) + SHA pinned in dev and prod Dockerfiles; `node:24-alpine`, `composer:latest`, `ollama/ollama:0.18.0` pinned to manifest list SHA — eliminates mutable tag risk
- **`npm install` → `npm ci`** in dev `entrypoint.sh` — reproducible installs using exact lockfile; eliminates non-deterministic dependency resolution