### PR TITLE
fix(deps): bump serialize-javascript npm override 7.0.3 → 7.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.15.2] - 2026-03-30
+
+### Security
+- **`serialize-javascript` override bumped** (npm `7.0.3` → `7.0.5`): resolved GHSA-qj8w-gfj5-8c6v (CPU Exhaustion DoS via crafted array-like objects) across all dependents (`css-minimizer-webpack-plugin`, `terser-webpack-plugin`, `@symfony/webpack-encore 5.x`); fixed via npm `overrides` entry — avoids a breaking upgrade to `@symfony/webpack-encore` v6; `package-lock.json` updated with pinned resolved version
+
+---
+
 ## [1.15.1] - 2026-03-27
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PDF Content Search
 
-[![Version](https://img.shields.io/badge/Version-1.15.1-blue.svg)](https://github.com/josego85/pdf-content-search)
+[![Version](https://img.shields.io/badge/Version-1.15.2-blue.svg)](https://github.com/josego85/pdf-content-search)
 [![PHP](https://img.shields.io/badge/PHP-8.4-777BB4?logo=php&logoColor=white)](https://www.php.net/)
 [![Symfony](https://img.shields.io/badge/Symfony-7.4-000000?logo=symfony&logoColor=white)](https://symfony.com/)
 [![Elasticsearch](https://img.shields.io/badge/Elasticsearch-9.3-005571?logo=elasticsearch&logoColor=white)](https://www.elastic.co/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6885,9 +6885,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
-      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "vue3-apexcharts": "1.10.0"
   },
   "overrides": {
-    "serialize-javascript": "7.0.3"
+    "serialize-javascript": "7.0.5"
   },
   "devDependencies": {
     "@babel/core": "7.29.0",


### PR DESCRIPTION
Resolves GHSA-qj8w-gfj5-8c6v (CPU Exhaustion DoS via crafted array-like objects) in serialize-javascript and its dependents (css-minimizer-webpack-plugin, terser-webpack-plugin, @symfony/webpack-encore 5.x).

Fixed via the existing npm `overrides` entry — no breaking upgrade to webpack-encore v6 required. package-lock.json updated with the pinned resolved version (7.0.5). Webpack production build verified clean after the change.

Closes: npm audit GHSA-qj8w-gfj5-8c6v