### PR TITLE
chore(deps): upgrade PHPStan to 2.1.45 and improve static analysis config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.15.2] - 2026-03-30
 
+### Changed
+- **PHPStan upgraded** (`2.1.39` → `2.1.45`): patch release — false positive fixes and improved type inference for PHP 8.4 features
+- **`phpstan/phpstan-doctrine` upgraded** (`2.0.16` → `2.0.20`): improved Doctrine 3.x entity and repository type analysis
+- **`phpstan/phpstan-symfony` upgraded** (`2.0.14` → `2.0.15`): improved Symfony 7.4 service and event type analysis
+- **`phpstan.neon`**: added `reportUnmatchedIgnoredErrors: true` — PHPStan now fails if a baseline entry no longer matches any real error, preventing stale suppression rules from accumulating
+
+### Fixed
+- **`LanguageDetector::detect()`**: added explicit `(string)` cast on `array_key_first()` return value — `array_key_first` returns `int|string`; cast guarantees the `language` key always satisfies the declared `array{language: string, …}` return type; removes one entry from `phpstan-baseline.neon`
+
 ### Security
 - **`serialize-javascript` override bumped** (npm `7.0.3` → `7.0.5`): resolved GHSA-qj8w-gfj5-8c6v (CPU Exhaustion DoS via crafted array-like objects) across all dependents (`css-minimizer-webpack-plugin`, `terser-webpack-plugin`, `@symfony/webpack-encore 5.x`); fixed via npm `overrides` entry — avoids a breaking upgrade to `@symfony/webpack-encore` v6; `package-lock.json` updated with pinned resolved version
 

--- a/composer.json
+++ b/composer.json
@@ -102,9 +102,9 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "3.94.0",
-    "phpstan/phpstan": "2.1.39",
-    "phpstan/phpstan-doctrine": "2.0.16",
-    "phpstan/phpstan-symfony": "2.0.14",
+    "phpstan/phpstan": "2.1.45",
+    "phpstan/phpstan-doctrine": "2.0.20",
+    "phpstan/phpstan-symfony": "2.0.15",
     "phpunit/phpunit": "9.6.34",
     "rector/rector": "2.3.8",
     "symfony/browser-kit": ">=7.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3509d68afa1f9eb90741c1697d5bb6ae",
+    "content-hash": "88a376737f5af1fe30e27182307d42fc",
     "packages": [
         {
             "name": "composer/semver",
@@ -9245,11 +9245,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.39",
+            "version": "2.1.45",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c6f73a2af4cbcd99c931d0fb8f08548cc0fa8224",
-                "reference": "c6f73a2af4cbcd99c931d0fb8f08548cc0fa8224",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f8cdfd9421b7edb7686a2d150a234870464eac70",
+                "reference": "f8cdfd9421b7edb7686a2d150a234870464eac70",
                 "shasum": ""
             },
             "require": {
@@ -9294,20 +9294,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-11T14:48:56+00:00"
+            "time": "2026-03-30T13:22:02+00:00"
         },
         {
             "name": "phpstan/phpstan-doctrine",
-            "version": "2.0.16",
+            "version": "2.0.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-doctrine.git",
-                "reference": "f4ff6084a26d91174b3f0b047589af293a893104"
+                "reference": "72f4f7a02d6c98d9101e8616e0488bc0a785196d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/f4ff6084a26d91174b3f0b047589af293a893104",
-                "reference": "f4ff6084a26d91174b3f0b047589af293a893104",
+                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/72f4f7a02d6c98d9101e8616e0488bc0a785196d",
+                "reference": "72f4f7a02d6c98d9101e8616e0488bc0a785196d",
                 "shasum": ""
             },
             "require": {
@@ -9332,7 +9332,7 @@
                 "doctrine/lexer": "^2.0 || ^3.0",
                 "doctrine/mongodb-odm": "^2.4.3",
                 "doctrine/orm": "^2.16.0",
-                "doctrine/persistence": "^2.2.1 || ^3.2",
+                "doctrine/persistence": "^2.2.1 || ^3.4.3",
                 "gedmo/doctrine-extensions": "^3.8",
                 "nesbot/carbon": "^2.49",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
@@ -9368,22 +9368,22 @@
             ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-doctrine/issues",
-                "source": "https://github.com/phpstan/phpstan-doctrine/tree/2.0.16"
+                "source": "https://github.com/phpstan/phpstan-doctrine/tree/2.0.20"
             },
-            "time": "2026-02-11T08:54:45+00:00"
+            "time": "2026-03-13T13:44:51+00:00"
         },
         {
             "name": "phpstan/phpstan-symfony",
-            "version": "2.0.14",
+            "version": "2.0.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-symfony.git",
-                "reference": "678136545a552a33b07f1a59a013f76df286cc34"
+                "reference": "9b85ab476969b87bbe2253b69e265a9359b2f395"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/678136545a552a33b07f1a59a013f76df286cc34",
-                "reference": "678136545a552a33b07f1a59a013f76df286cc34",
+                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/9b85ab476969b87bbe2253b69e265a9359b2f395",
+                "reference": "9b85ab476969b87bbe2253b69e265a9359b2f395",
                 "shasum": ""
             },
             "require": {
@@ -9442,9 +9442,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-symfony/issues",
-                "source": "https://github.com/phpstan/phpstan-symfony/tree/2.0.14"
+                "source": "https://github.com/phpstan/phpstan-symfony/tree/2.0.15"
             },
-            "time": "2026-02-11T12:27:30+00:00"
+            "time": "2026-02-26T10:15:59+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -17,9 +17,3 @@ parameters:
 			identifier: method.notFound
 			count: 1
 			path: src/Service/ElasticsearchService.php
-
-		-
-			message: '#^Method App\\Service\\LanguageDetector\:\:detect\(\) should return array\{language\: string, confidence\: float, all\: array\<string, float\>\} but returns array\{language\: int\|string, confidence\: mixed, all\: array\}\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Service/LanguageDetector.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,6 +2,7 @@ parameters:
     level: 8
     paths:
         - src/
+    reportUnmatchedIgnoredErrors: true
     symfony:
         containerXmlPath: var/cache/dev/App_KernelDevDebugContainer.xml
     excludePaths:

--- a/src/Service/LanguageDetector.php
+++ b/src/Service/LanguageDetector.php
@@ -37,7 +37,7 @@ final readonly class LanguageDetector implements LanguageDetectorInterface
         $results = $this->detector->detect($sample)->bestResults()->close();
 
         return [
-            'language' => array_key_first($results) ?? 'unknown',
+            'language' => (string) (array_key_first($results) ?? 'unknown'),
             'confidence' => reset($results) ?: 0.0,
             'all' => $results,
         ];


### PR DESCRIPTION
 - phpstan/phpstan 2.1.39 → 2.1.45
- phpstan/phpstan-doctrine 2.0.16 → 2.0.20
- phpstan/phpstan-symfony 2.0.14 → 2.0.15
- Add reportUnmatchedIgnoredErrors: true to phpstan.neon to detect stale baseline entries automatically
- Fix LanguageDetector::detect() return type with explicit (string) cast on array_key_first() — removes one entry from phpstan-baseline.neon