### PR TITLE
Chore/upgrade php cs fixer rector add ci script

### DIFF
--- a/.claude/commands/quality-check.md
+++ b/.claude/commands/quality-check.md
@@ -19,7 +19,7 @@ If it fails: run `composer cs-fix` to fix automatically, then show what changed.
 ## Step 3 — Rector (modernization)
 
 ```bash
-docker compose -f docker-compose.yml -f docker-compose.dev.yml exec -T php composer rector-dry
+docker compose -f docker-compose.yml -f docker-compose.dev.yml exec -T php composer rector-check
 ```
 
 If it finds changes: show them and ask the user whether to apply with `composer rector`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           timeout 60 bash -c 'until curl -s http://localhost:9200/_cluster/health | grep -q "green\|yellow"; do sleep 1; done'
 
       - name: Run All Tests with Coverage
-        run: vendor/bin/phpunit --coverage-clover coverage.xml --testdox
+        run: composer test -- --coverage-clover coverage.xml --testdox
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - develop
       - 'feature/**'
       - 'fix/**'
+      - 'chore/**'
       - 'claude/**'
   pull_request:
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
         uses: ./.github/actions/setup-php-project
 
       - name: Run Rector (dry-run)
-        run: composer rector-dry
+        run: composer rector-check
 
   frontend-lint:
     name: Frontend Linting (Biome)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,8 @@ on:
       - main
       - develop
       - 'feature/**'
+      - 'fix/**'
+      - 'chore/**'
       - 'claude/**'
   pull_request:
     branches:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -6,6 +6,8 @@ on:
       - main
       - develop
       - 'feature/**'
+      - 'fix/**'
+      - 'chore/**'
       - 'claude/**'
   pull_request:
     branches:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -24,8 +24,15 @@ if ! docker compose -f docker-compose.yml -f docker-compose.dev.yml exec -T php 
 fi
 echo "✅ PHPStan passed."
 
+echo "🏛 Running Rector check..."
+if ! docker compose -f docker-compose.yml -f docker-compose.dev.yml exec -T php composer rector-check; then
+  echo "❌ Rector found pending changes. Run: make rector-fix"
+  exit 1
+fi
+echo "✅ Rector clean."
+
 echo "🧪 Running tests..."
-if ! docker compose -f docker-compose.yml -f docker-compose.dev.yml exec -T php bash -c "XDEBUG_MODE=coverage php bin/phpunit"; then
+if ! docker compose -f docker-compose.yml -f docker-compose.dev.yml exec -T php composer test; then
   echo "❌ Tests failed. Fix them before committing."
   exit 1
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`phpstan.neon`**: added `reportUnmatchedIgnoredErrors: true` — PHPStan now fails if a baseline entry no longer matches any real error, preventing stale suppression rules from accumulating
 - **`rector/rector` upgraded** (`2.3.8` → `2.3.9`): patch release — bug fixes in PHP 8.4 rules and Symfony 7.4 rector set
 - **`friendsofphp/php-cs-fixer` upgraded** (`3.94.0` → `3.94.2`): patch release — fixer rule corrections and false-positive reductions
+- **`composer.json` — `rector-dry` renamed to `rector-check`**: aligns naming with `cs-check` — both scripts verify without modifying; updated in `Makefile`, `ci.yml`, and `.claude/commands/quality-check.md`
 - **`composer.json` — new `test` script**: alias for `vendor/bin/phpunit`; accepts pass-through arguments via `--`
-- **`composer.json` — new `ci` script**: chains `cs-check` → `phpstan` → `rector-dry` → `test` in a single local command; mirrors the checks enforced by GitHub Actions CI
+- **`composer.json` — new `ci` script**: chains `cs-check` → `phpstan` → `rector-check` → `test` in a single local command; mirrors the checks enforced by GitHub Actions CI
 - **`ci.yml` — `php-tests` job**: test step now calls `composer test -- ...` instead of `vendor/bin/phpunit` directly, ensuring the CI pipeline is consistent with the local `composer test` script
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`phpstan/phpstan-doctrine` upgraded** (`2.0.16` → `2.0.20`): improved Doctrine 3.x entity and repository type analysis
 - **`phpstan/phpstan-symfony` upgraded** (`2.0.14` → `2.0.15`): improved Symfony 7.4 service and event type analysis
 - **`phpstan.neon`**: added `reportUnmatchedIgnoredErrors: true` — PHPStan now fails if a baseline entry no longer matches any real error, preventing stale suppression rules from accumulating
+- **`rector/rector` upgraded** (`2.3.8` → `2.3.9`): patch release — bug fixes in PHP 8.4 rules and Symfony 7.4 rector set
+- **`friendsofphp/php-cs-fixer` upgraded** (`3.94.0` → `3.94.2`): patch release — fixer rule corrections and false-positive reductions
+- **`composer.json` — new `test` script**: alias for `vendor/bin/phpunit`; accepts pass-through arguments via `--`
+- **`composer.json` — new `ci` script**: chains `cs-check` → `phpstan` → `rector-dry` → `test` in a single local command; mirrors the checks enforced by GitHub Actions CI
+- **`ci.yml` — `php-tests` job**: test step now calls `composer test -- ...` instead of `vendor/bin/phpunit` directly, ensuring the CI pipeline is consistent with the local `composer test` script
 
 ### Fixed
 - **`LanguageDetector::detect()`**: added explicit `(string)` cast on `array_key_first()` return value — `array_key_first` returns `int|string`; cast guarantees the `language` key always satisfies the declared `array{language: string, …}` return type; removes one entry from `phpstan-baseline.neon`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -399,7 +399,10 @@ Always use `make` for common tasks. Check `Makefile` before running raw docker/c
 |---|---|---|
 | `ci.yml` | push / PR | PHPUnit (85% coverage), PHPStan, PHP-CS-Fixer, Rector, Biome, Webpack build |
 | `security-audit.yml` | push / PR / daily 2am UTC | npm audit, composer audit, dependency-review |
-| `codeql.yml` | push / PR | SAST (PHP vulnerability scanning) |
+| `codeql.yml` | push / PR / weekly Monday 6am UTC | SAST (PHP vulnerability scanning) |
+
+### Push Trigger Branches (all three workflows)
+`main`, `develop`, `feature/**`, `fix/**`, `chore/**`, `claude/**`
 
 ### CI Requirements (All Must Pass)
 1. PHPUnit — ≥85% line coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,7 +384,7 @@ Always use `make` for common tasks. Check `Makefile` before running raw docker/c
 | `make down` | Stop all services |
 | `make test` | Run PHPUnit test suite |
 | `make phpstan` | Run PHPStan Level 8 static analysis |
-| `make rector` | Run Rector in dry-run mode |
+| `make rector` | Run Rector in check mode (no writes) |
 | `make rector-fix` | Apply Rector refactoring |
 | `make shell` | Open bash in PHP container |
 | `make logs` | Tail all container logs |
@@ -415,10 +415,38 @@ Do not merge pull requests with CI failures.
 
 ---
 
+## Husky Pre-commit Hook
+
+`.husky/pre-commit` runs automatically on every `git commit` when the dev containers are up.
+
+### Design Rules
+- **Graceful skip** — if the `php` container is not running, the hook exits 0 and warns; CI is the real quality gate
+- **No coverage in pre-commit** — `XDEBUG_MODE=coverage` is intentionally absent; coverage instrumentation makes the suite 5–10x slower and belongs in CI only (`--coverage-clover coverage.xml`)
+- **Mirrors `composer ci`** — checks run in the same order and use the same composer scripts for consistency
+
+### Checks (in order)
+| Step | Command | Fail action |
+|---|---|---|
+| PHP-CS-Fixer | `composer cs-check` | `Run: make cs-fix` |
+| PHPStan | `composer phpstan` | Fix errors before committing |
+| Rector | `composer rector-check` | `Run: make rector-fix` |
+| PHPUnit | `composer test` | Fix failing tests |
+| Biome | `npm run lint --silent` | `Run: npm run lint` |
+
+### Why Keep Husky Separate from `composer ci`
+- `composer ci` is PHP-only — cannot include Biome (Node.js)
+- Husky provides per-check actionable error messages and graceful skip logic
+- `composer ci` is the local convenience script; Husky is the automated gate
+
+---
+
 ## Code Quality Tools
 
 ### PHP Static Analysis
 ```bash
+# Run all checks in sequence (local CI equivalent)
+docker compose exec php composer ci
+
 # PHPStan
 docker compose exec php composer phpstan
 # or: make phpstan
@@ -429,13 +457,17 @@ docker compose exec php composer cs-check
 # PHP-CS-Fixer (fix)
 docker compose exec php composer cs-fix
 
-# Rector (dry-run — see what would change)
-docker compose exec php composer rector-dry
+# Rector (check — see what would change, no writes)
+docker compose exec php composer rector-check
 # or: make rector
 
 # Rector (apply)
 docker compose exec php composer rector
 # or: make rector-fix
+
+# Run tests
+docker compose exec php composer test
+# or: make test
 ```
 
 ### Frontend Linting

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # ============================================
 
 .DEFAULT_GOAL := help
-.PHONY: help dev prod up down restart logs shell test phpstan rector rector-dry clean rebuild status
+.PHONY: help dev prod up down restart logs shell test phpstan rector rector-check clean rebuild status
 
 # Colors for output
 BLUE := \033[0;34m
@@ -156,8 +156,8 @@ test: ## Run tests in development environment
 phpstan: ## Run PHPStan static analysis
 	@$(COMPOSE_DEV) exec php composer phpstan
 
-rector: ## Run Rector in dry-run mode (preview changes, no writes)
-	@$(COMPOSE_DEV) exec php composer rector-dry
+rector: ## Run Rector in check mode (preview changes, no writes)
+	@$(COMPOSE_DEV) exec php composer rector-check
 
 rector-fix: ## Run Rector and apply changes (always run rector first!)
 	@$(COMPOSE_DEV) exec php composer rector

--- a/composer.json
+++ b/composer.json
@@ -82,16 +82,25 @@
     "cs-fix": "php-cs-fixer fix --config=.php-cs-fixer.dist.php",
     "phpstan": "phpstan analyse",
     "rector": "rector process",
-    "rector-dry": "rector process --dry-run",
+    "rector-check": "rector process --dry-run",
     "test": "vendor/bin/phpunit",
-    "ci": ["@cs-check", "@phpstan", "@rector-dry", "@test"],
+    "ci": [
+      "@cs-check",
+      "@phpstan",
+      "@rector-check",
+      "@test"
+    ],
     "auto-scripts": {
       "cache:clear": "symfony-cmd",
       "assets:install %PUBLIC_DIR%": "symfony-cmd",
       "importmap:install": "symfony-cmd"
     },
-    "post-install-cmd": ["@auto-scripts"],
-    "post-update-cmd": ["@auto-scripts"]
+    "post-install-cmd": [
+      "@auto-scripts"
+    ],
+    "post-update-cmd": [
+      "@auto-scripts"
+    ]
   },
   "conflict": {
     "symfony/symfony": "*"

--- a/composer.json
+++ b/composer.json
@@ -84,23 +84,14 @@
     "rector": "rector process",
     "rector-check": "rector process --dry-run",
     "test": "vendor/bin/phpunit",
-    "ci": [
-      "@cs-check",
-      "@phpstan",
-      "@rector-check",
-      "@test"
-    ],
+    "ci": ["@cs-check", "@phpstan", "@rector-check", "@test"],
     "auto-scripts": {
       "cache:clear": "symfony-cmd",
       "assets:install %PUBLIC_DIR%": "symfony-cmd",
       "importmap:install": "symfony-cmd"
     },
-    "post-install-cmd": [
-      "@auto-scripts"
-    ],
-    "post-update-cmd": [
-      "@auto-scripts"
-    ]
+    "post-install-cmd": ["@auto-scripts"],
+    "post-update-cmd": ["@auto-scripts"]
   },
   "conflict": {
     "symfony/symfony": "*"

--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,8 @@
     "phpstan": "phpstan analyse",
     "rector": "rector process",
     "rector-dry": "rector process --dry-run",
+    "test": "vendor/bin/phpunit",
+    "ci": ["@cs-check", "@phpstan", "@rector-dry", "@test"],
     "auto-scripts": {
       "cache:clear": "symfony-cmd",
       "assets:install %PUBLIC_DIR%": "symfony-cmd",
@@ -101,12 +103,12 @@
     }
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "3.94.0",
+    "friendsofphp/php-cs-fixer": "3.94.2",
     "phpstan/phpstan": "2.1.45",
     "phpstan/phpstan-doctrine": "2.0.20",
     "phpstan/phpstan-symfony": "2.0.15",
     "phpunit/phpunit": "9.6.34",
-    "rector/rector": "2.3.8",
+    "rector/rector": "2.3.9",
     "symfony/browser-kit": ">=7.4.0",
     "symfony/css-selector": ">=7.4.0",
     "symfony/debug-bundle": "7.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "88a376737f5af1fe30e27182307d42fc",
+    "content-hash": "9c65349392c78ec3ff6e6e5e5f1a6636",
     "packages": [
         {
             "name": "composer/semver",
@@ -1554,16 +1554,16 @@
         },
         {
             "name": "open-telemetry/api",
-            "version": "1.8.0",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opentelemetry-php/api.git",
-                "reference": "df5197c6fd0ddd8e9883b87de042d9341300e2ad"
+                "reference": "6f8d237ce2c304ca85f31970f788e7f074d147be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opentelemetry-php/api/zipball/df5197c6fd0ddd8e9883b87de042d9341300e2ad",
-                "reference": "df5197c6fd0ddd8e9883b87de042d9341300e2ad",
+                "url": "https://api.github.com/repos/opentelemetry-php/api/zipball/6f8d237ce2c304ca85f31970f788e7f074d147be",
+                "reference": "6f8d237ce2c304ca85f31970f788e7f074d147be",
                 "shasum": ""
             },
             "require": {
@@ -1620,20 +1620,20 @@
                 "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
-            "time": "2026-01-21T04:14:03+00:00"
+            "time": "2026-02-25T13:24:05+00:00"
         },
         {
             "name": "open-telemetry/context",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opentelemetry-php/context.git",
-                "reference": "d4c4470b541ce72000d18c339cfee633e4c8e0cf"
+                "reference": "3c414b246e0dabb7d6145404e6a5e4536ca18d07"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opentelemetry-php/context/zipball/d4c4470b541ce72000d18c339cfee633e4c8e0cf",
-                "reference": "d4c4470b541ce72000d18c339cfee633e4c8e0cf",
+                "url": "https://api.github.com/repos/opentelemetry-php/context/zipball/3c414b246e0dabb7d6145404e6a5e4536ca18d07",
+                "reference": "3c414b246e0dabb7d6145404e6a5e4536ca18d07",
                 "shasum": ""
             },
             "require": {
@@ -1675,11 +1675,11 @@
             ],
             "support": {
                 "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V",
-                "docs": "https://opentelemetry.io/docs/php",
+                "docs": "https://opentelemetry.io/docs/languages/php",
                 "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
-            "time": "2025-09-19T00:05:49+00:00"
+            "time": "2025-10-19T06:44:33+00:00"
         },
         {
             "name": "patrickschur/language-detection",
@@ -2768,16 +2768,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "1d06192e8f164e2729b0031e6807d72a6195b8bb"
+                "reference": "665522ec357540e66c294c08583b40ee576574f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/1d06192e8f164e2729b0031e6807d72a6195b8bb",
-                "reference": "1d06192e8f164e2729b0031e6807d72a6195b8bb",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/665522ec357540e66c294c08583b40ee576574f0",
+                "reference": "665522ec357540e66c294c08583b40ee576574f0",
                 "shasum": ""
             },
             "require": {
@@ -2848,7 +2848,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v7.4.6"
+                "source": "https://github.com/symfony/cache/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -2868,7 +2868,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-21T23:29:27+00:00"
+            "time": "2026-03-06T08:14:57+00:00"
         },
         {
             "name": "symfony/cache-contracts",
@@ -3026,16 +3026,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "9400e2f9226b3b64ebb0a8ae967ae84e54e39640"
+                "reference": "6c17162555bfb58957a55bb0e43e00035b6ae3d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/9400e2f9226b3b64ebb0a8ae967ae84e54e39640",
-                "reference": "9400e2f9226b3b64ebb0a8ae967ae84e54e39640",
+                "url": "https://api.github.com/repos/symfony/config/zipball/6c17162555bfb58957a55bb0e43e00035b6ae3d5",
+                "reference": "6c17162555bfb58957a55bb0e43e00035b6ae3d5",
                 "shasum": ""
             },
             "require": {
@@ -3081,7 +3081,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v7.4.6"
+                "source": "https://github.com/symfony/config/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -3101,7 +3101,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-25T16:50:00+00:00"
+            "time": "2026-03-06T10:41:14+00:00"
         },
         {
             "name": "symfony/console",
@@ -3203,16 +3203,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "a3f7d594ca53a34a7d39ae683fbca09408b0c598"
+                "reference": "0f651e58f4917fb0e2cd261ccbfe3d71e6e0f5db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/a3f7d594ca53a34a7d39ae683fbca09408b0c598",
-                "reference": "a3f7d594ca53a34a7d39ae683fbca09408b0c598",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/0f651e58f4917fb0e2cd261ccbfe3d71e6e0f5db",
+                "reference": "0f651e58f4917fb0e2cd261ccbfe3d71e6e0f5db",
                 "shasum": ""
             },
             "require": {
@@ -3263,7 +3263,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.6"
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -3283,7 +3283,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-25T16:50:00+00:00"
+            "time": "2026-03-03T07:48:48+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3354,16 +3354,16 @@
         },
         {
             "name": "symfony/doctrine-bridge",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/doctrine-bridge.git",
-                "reference": "710cb7313446aa5ce67e2da06c01f1640dfbdcc6"
+                "reference": "4fc5e2dd41be3c0b6321e0373072782edeff45ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/710cb7313446aa5ce67e2da06c01f1640dfbdcc6",
-                "reference": "710cb7313446aa5ce67e2da06c01f1640dfbdcc6",
+                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/4fc5e2dd41be3c0b6321e0373072782edeff45ed",
+                "reference": "4fc5e2dd41be3c0b6321e0373072782edeff45ed",
                 "shasum": ""
             },
             "require": {
@@ -3443,7 +3443,7 @@
             "description": "Provides integration for Doctrine with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/doctrine-bridge/tree/v7.4.6"
+                "source": "https://github.com/symfony/doctrine-bridge/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -3463,7 +3463,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-17T08:07:48+00:00"
+            "time": "2026-03-05T08:16:50+00:00"
         },
         {
             "name": "symfony/doctrine-messenger",
@@ -4583,16 +4583,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "fd97d5e926e988a363cef56fbbf88c5c528e9065"
+                "reference": "f94b3e7b7dafd40e666f0c9ff2084133bae41e81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/fd97d5e926e988a363cef56fbbf88c5c528e9065",
-                "reference": "fd97d5e926e988a363cef56fbbf88c5c528e9065",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/f94b3e7b7dafd40e666f0c9ff2084133bae41e81",
+                "reference": "f94b3e7b7dafd40e666f0c9ff2084133bae41e81",
                 "shasum": ""
             },
             "require": {
@@ -4641,7 +4641,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.4.6"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -4661,20 +4661,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-21T16:25:55+00:00"
+            "time": "2026-03-06T13:15:18+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "002ac0cf4cd972a7fd0912dcd513a95e8a81ce83"
+                "reference": "3b3fcf386c809be990c922e10e4c620d6367cab1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/002ac0cf4cd972a7fd0912dcd513a95e8a81ce83",
-                "reference": "002ac0cf4cd972a7fd0912dcd513a95e8a81ce83",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/3b3fcf386c809be990c922e10e4c620d6367cab1",
+                "reference": "3b3fcf386c809be990c922e10e4c620d6367cab1",
                 "shasum": ""
             },
             "require": {
@@ -4760,7 +4760,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.4.6"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -4780,7 +4780,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-26T08:30:57+00:00"
+            "time": "2026-03-06T16:33:18+00:00"
         },
         {
             "name": "symfony/intl",
@@ -7505,16 +7505,16 @@
         },
         {
             "name": "symfony/twig-bridge",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/twig-bridge.git",
-                "reference": "8903bc9a64cf624ffe522893f3626d5a0b97175c"
+                "reference": "c67219ca6b79a57b64e36bbb2cd8ba741286587e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/8903bc9a64cf624ffe522893f3626d5a0b97175c",
-                "reference": "8903bc9a64cf624ffe522893f3626d5a0b97175c",
+                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/c67219ca6b79a57b64e36bbb2cd8ba741286587e",
+                "reference": "c67219ca6b79a57b64e36bbb2cd8ba741286587e",
                 "shasum": ""
             },
             "require": {
@@ -7596,7 +7596,7 @@
             "description": "Provides integration for Twig with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/twig-bridge/tree/v7.4.6"
+                "source": "https://github.com/symfony/twig-bridge/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -7616,7 +7616,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-25T16:50:00+00:00"
+            "time": "2026-03-04T15:37:05+00:00"
         },
         {
             "name": "symfony/twig-bundle",
@@ -7710,16 +7710,16 @@
         },
         {
             "name": "symfony/type-info",
-            "version": "v7.4.6",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/type-info.git",
-                "reference": "4855ceea609b2c09e48ff76e12a97a3955531735"
+                "reference": "31f1e40cbf7851c7354281c90eb1b352c4cb8269"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/type-info/zipball/4855ceea609b2c09e48ff76e12a97a3955531735",
-                "reference": "4855ceea609b2c09e48ff76e12a97a3955531735",
+                "url": "https://api.github.com/repos/symfony/type-info/zipball/31f1e40cbf7851c7354281c90eb1b352c4cb8269",
+                "reference": "31f1e40cbf7851c7354281c90eb1b352c4cb8269",
                 "shasum": ""
             },
             "require": {
@@ -7769,7 +7769,7 @@
                 "type"
             ],
             "support": {
-                "source": "https://github.com/symfony/type-info/tree/v7.4.6"
+                "source": "https://github.com/symfony/type-info/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -7789,7 +7789,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-17T14:00:31+00:00"
+            "time": "2026-03-04T12:49:16+00:00"
         },
         {
             "name": "symfony/validator",
@@ -8304,16 +8304,16 @@
         },
         {
             "name": "twig/extra-bundle",
-            "version": "v3.23.0",
+            "version": "v3.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/twig-extra-bundle.git",
-                "reference": "7a27e784dc56eddfef5e9295829b290ce06f1682"
+                "reference": "6a621fcb1f28aa9ea7b34a99047ae0cdf5b834c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/twig-extra-bundle/zipball/7a27e784dc56eddfef5e9295829b290ce06f1682",
-                "reference": "7a27e784dc56eddfef5e9295829b290ce06f1682",
+                "url": "https://api.github.com/repos/twigphp/twig-extra-bundle/zipball/6a621fcb1f28aa9ea7b34a99047ae0cdf5b834c9",
+                "reference": "6a621fcb1f28aa9ea7b34a99047ae0cdf5b834c9",
                 "shasum": ""
             },
             "require": {
@@ -8362,7 +8362,7 @@
                 "twig"
             ],
             "support": {
-                "source": "https://github.com/twigphp/twig-extra-bundle/tree/v3.23.0"
+                "source": "https://github.com/twigphp/twig-extra-bundle/tree/v3.24.0"
             },
             "funding": [
                 {
@@ -8374,20 +8374,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-18T20:46:15+00:00"
+            "time": "2026-02-07T08:07:38+00:00"
         },
         {
             "name": "twig/twig",
-            "version": "v3.23.0",
+            "version": "v3.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "a64dc5d2cc7d6cafb9347f6cd802d0d06d0351c9"
+                "reference": "a6769aefb305efef849dc25c9fd1653358c148f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/a64dc5d2cc7d6cafb9347f6cd802d0d06d0351c9",
-                "reference": "a64dc5d2cc7d6cafb9347f6cd802d0d06d0351c9",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/a6769aefb305efef849dc25c9fd1653358c148f0",
+                "reference": "a6769aefb305efef849dc25c9fd1653358c148f0",
                 "shasum": ""
             },
             "require": {
@@ -8397,7 +8397,8 @@
                 "symfony/polyfill-mbstring": "^1.3"
             },
             "require-dev": {
-                "phpstan/phpstan": "^2.0",
+                "php-cs-fixer/shim": "^3.0@stable",
+                "phpstan/phpstan": "^2.0@stable",
                 "psr/container": "^1.0|^2.0",
                 "symfony/phpunit-bridge": "^5.4.9|^6.4|^7.0"
             },
@@ -8441,7 +8442,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.23.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.24.0"
             },
             "funding": [
                 {
@@ -8453,7 +8454,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-23T21:00:41+00:00"
+            "time": "2026-03-17T21:31:11+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -8838,16 +8839,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.94.0",
+            "version": "v3.94.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "883b20fb38c7866de9844ab6d0a205c423bde2d4"
+                "reference": "7787ceff91365ba7d623ec410b8f429cdebb4f63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/883b20fb38c7866de9844ab6d0a205c423bde2d4",
-                "reference": "883b20fb38c7866de9844ab6d0a205c423bde2d4",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/7787ceff91365ba7d623ec410b8f429cdebb4f63",
+                "reference": "7787ceff91365ba7d623ec410b8f429cdebb4f63",
                 "shasum": ""
             },
             "require": {
@@ -8930,7 +8931,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.94.0"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.94.2"
             },
             "funding": [
                 {
@@ -8938,7 +8939,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-11T16:44:33+00:00"
+            "time": "2026-02-20T16:13:53+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -10404,21 +10405,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.3.8",
+            "version": "2.3.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "bbd37aedd8df749916cffa2a947cfc4714d1ba2c"
+                "reference": "917842143fd9f5331a2adefc214b8d7143bd32c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/bbd37aedd8df749916cffa2a947cfc4714d1ba2c",
-                "reference": "bbd37aedd8df749916cffa2a947cfc4714d1ba2c",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/917842143fd9f5331a2adefc214b8d7143bd32c4",
+                "reference": "917842143fd9f5331a2adefc214b8d7143bd32c4",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.38"
+                "phpstan/phpstan": "^2.1.40"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -10452,7 +10453,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.3.8"
+                "source": "https://github.com/rectorphp/rector/tree/2.3.9"
             },
             "funding": [
                 {
@@ -10460,7 +10461,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-22T09:45:50+00:00"
+            "time": "2026-03-16T09:43:55+00:00"
         },
         {
             "name": "sebastian/cli-parser",


### PR DESCRIPTION
### Changed

- **`rector/rector` upgraded** (`2.3.8` → `2.3.9`): patch release — bug fixes in PHP 8.4 rules and Symfony 7.4 rector set
- **`friendsofphp/php-cs-fixer` upgraded** (`3.94.0` → `3.94.2`): patch release — fixer rule corrections and false-positive reductions
- **`composer.json` — `rector-dry` renamed to `rector-check`**: aligns naming with `cs-check` — both scripts verify without modifying; updated in `Makefile`, `ci.yml`, and `.claude/commands/quality-check.md`
- **`composer.json` — new `test` script**: alias for `vendor/bin/phpunit`; accepts pass-through arguments via `--`
- **`composer.json` — new `ci` script**: chains `cs-check` → `phpstan` → `rector-check` → `test` in a single local command; mirrors the checks enforced by GitHub Actions CI
- **`ci.yml` — `php-tests` job**: test step now calls `composer test -- ...` instead of `vendor/bin/phpunit` directly, ensuring the CI pipeline is consistent with the local `composer test` script