### PR TITLE
fix(security): upgrade postcss to 8.5.12 to fix XSS vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.16.1] - 2026-04-26
+
+### Security
+- **`postcss` upgraded** (`8.5.6` → `8.5.12`): fixes [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) (XSS via unescaped `</style>` tag in CSS Stringify output) — severity: moderate; upgrade applied via `npm audit fix --force` as the target version falls outside the previous pin range
+
+---
+
 ## [1.16.0] - 2026-04-23
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,6 +311,8 @@ See `TODO.md`. These must be completed before public exposure:
 - `npm audit` — high/critical findings block CI
 - `composer audit` — CVE or abandoned packages block CI
 - Fix vulnerabilities by upgrading; do not suppress audit warnings without justification
+- For transitive deps pinned outside the stated range, `npm audit fix --force` is acceptable — always verify with `npm run build` + `npm run test` after applying
+- Use `overrides` in `package.json` only when a transitive dep cannot be upgraded directly (e.g. `uuid` GHSA-w5hq-g745-h8pq); prefer direct upgrades when available
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PDF Content Search
 
-[![Version](https://img.shields.io/badge/Version-1.16.0-blue.svg)](https://github.com/josego85/pdf-content-search)
+[![Version](https://img.shields.io/badge/Version-1.16.1-blue.svg)](https://github.com/josego85/pdf-content-search)
 [![PHP](https://img.shields.io/badge/PHP-8.4-777BB4?logo=php&logoColor=white)](https://www.php.net/)
 [![Symfony](https://img.shields.io/badge/Symfony-7.4-000000?logo=symfony&logoColor=white)](https://symfony.com/)
 [![Elasticsearch](https://img.shields.io/badge/Elasticsearch-9.3-005571?logo=elasticsearch&logoColor=white)](https://www.elastic.co/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "happy-dom": "20.8.9",
         "husky": "9.1.7",
         "jsdom": "29.0.1",
-        "postcss": "8.5.6",
+        "postcss": "8.5.12",
         "postcss-loader": "^7.3.4",
         "regenerator-runtime": "0.13.11",
         "sass": "1.97.3",
@@ -7572,9 +7572,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",
@@ -9712,35 +9712,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "happy-dom": "20.8.9",
     "husky": "9.1.7",
     "jsdom": "29.0.1",
-    "postcss": "8.5.6",
+    "postcss": "8.5.12",
     "postcss-loader": "^7.3.4",
     "regenerator-runtime": "0.13.11",
     "sass": "1.97.3",


### PR DESCRIPTION
### Security
- **`postcss` upgraded** (`8.5.6` → `8.5.12`): fixes [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) (XSS via unescaped `</style>` tag in CSS Stringify output) — severity: moderate; upgrade applied via `npm audit fix --force` as the target version falls outside the previous pin range