### PR TITLE
fix(security): upgrade babel-systemjs 7.29.4 and fast-uri 3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.16.2] - 2026-05-09
+
+### Security
+- **`@babel/plugin-transform-modules-systemjs` upgraded** (`7.29.0` → `7.29.4`): fixes [GHSA-fv7c-fp4j-7gwp](https://github.com/advisories/GHSA-fv7c-fp4j-7gwp) (arbitrary code generation when compiling malicious input) — severity: high; build-time only (Webpack/Babel toolchain, not app runtime); patched via `npm audit fix` within semver range `^7.29.0`
+- **`fast-uri` upgraded** (`3.1.0` → `3.1.2`): fixes [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) (path traversal via percent-encoded dot segments) and [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) (host confusion via percent-encoded authority delimiters) — severity: high; build-time only (webpack → schema-utils → ajv → fast-uri, not app runtime); patched via `npm audit fix` within semver range `^3.0.1`
+
+---
+
 ## [1.16.1] - 2026-04-26
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,7 +312,17 @@ See `TODO.md`. These must be completed before public exposure:
 - `composer audit` — CVE or abandoned packages block CI
 - Fix vulnerabilities by upgrading; do not suppress audit warnings without justification
 - For transitive deps pinned outside the stated range, `npm audit fix --force` is acceptable — always verify with `npm run build` + `npm run test` after applying
+- For transitive deps within the stated semver range, `npm audit fix` (no `--force`) is sufficient — no `overrides` or code changes needed
 - Use `overrides` in `package.json` only when a transitive dep cannot be upgraded directly (e.g. `uuid` GHSA-w5hq-g745-h8pq); prefer direct upgrades when available
+
+### Security Patch History
+| Version | Package | Advisory | Fix method |
+|---|---|---|---|
+| 1.16.0 | `uuid` 8.3.2 → 14.0.0 | GHSA-w5hq-g745-h8pq (moderate) | `overrides` in package.json |
+| 1.16.0 | `lodash` 4.17.23 → 4.18.1 | GHSA-r5fr-rjxr-66jc + GHSA-f23m-r3pf-42rh (high) | direct upgrade |
+| 1.16.1 | `postcss` 8.5.6 → ^8.5.12 | GHSA-qx2v-qp2m-jg93 (moderate) | `npm audit fix --force` (outside stated range) |
+| 1.16.2 | `@babel/plugin-transform-modules-systemjs` 7.29.0 → 7.29.4 | GHSA-fv7c-fp4j-7gwp (high, build-time only) | `npm audit fix` (within `^7.29.0`) |
+| 1.16.2 | `fast-uri` 3.1.0 → 3.1.2 | GHSA-q3j6-qgpj-74h6 + GHSA-v39h-62p7-jpjc (high, build-time only) | `npm audit fix` (within `^3.0.1`) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PDF Content Search
 
-[![Version](https://img.shields.io/badge/Version-1.16.1-blue.svg)](https://github.com/josego85/pdf-content-search)
+[![Version](https://img.shields.io/badge/Version-1.16.2-blue.svg)](https://github.com/josego85/pdf-content-search)
 [![PHP](https://img.shields.io/badge/PHP-8.4-777BB4?logo=php&logoColor=white)](https://www.php.net/)
 [![Symfony](https://img.shields.io/badge/Symfony-7.4-000000?logo=symfony&logoColor=white)](https://symfony.com/)
 [![Elasticsearch](https://img.shields.io/badge/Elasticsearch-9.3-005571?logo=elasticsearch&logoColor=white)](https://www.elastic.co/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1048,9 +1048,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5542,9 +5542,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
### Security
- **`@babel/plugin-transform-modules-systemjs` upgraded** (`7.29.0` → `7.29.4`): fixes [GHSA-fv7c-fp4j-7gwp](https://github.com/advisories/GHSA-fv7c-fp4j-7gwp) (arbitrary code generation when compiling malicious input) — severity: high; build-time only (Webpack/Babel toolchain, not app runtime); patched via `npm audit fix` within semver range `^7.29.0`
- **`fast-uri` upgraded** (`3.1.0` → `3.1.2`): fixes [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) (path traversal via percent-encoded dot segments) and [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) (host confusion via percent-encoded authority delimiters) — severity: high; build-time only (webpack → schema-utils → ajv → fast-uri, not app runtime); patched via `npm audit fix` within semver range `^3.0.1`